### PR TITLE
Halo2 ecc snark verifier 0323

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Cargo.lock
 
 # local files
 *.srs
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ Cargo.lock
 # local files
 *.srs
 *.log
+*.snark
+*.sol

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 testdata
 
 Cargo.lock
+
+# local files
+*.srs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ incremental = false
 inherits = "release"
 debug = true
 
-# patch until PR https://github.com/privacy-scaling-explorations/halo2/pull/111 is merged
 [patch."https://github.com/privacy-scaling-explorations/halo2.git"]
-halo2_proofs = { git = "https://github.com/axiom-crypto/halo2.git", branch = "feat/serde-raw" }
+halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "halo2-ecc-snark-verifier-0323"  }
+[patch."https://github.com/privacy-scaling-explorations/poseidon.git"]
+poseidon = { git = "https://github.com/scroll-tech/poseidon.git", branch = "scroll-dev-0220" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,5 +36,6 @@ debug = true
 
 [patch."https://github.com/privacy-scaling-explorations/halo2.git"]
 halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "halo2-ecc-snark-verifier-0323"  }
+# halo2_proofs = { path = "../halo2/halo2_proofs" }
 [patch."https://github.com/privacy-scaling-explorations/poseidon.git"]
 poseidon = { git = "https://github.com/scroll-tech/poseidon.git", branch = "scroll-dev-0220" }

--- a/snark-verifier-sdk/Cargo.toml
+++ b/snark-verifier-sdk/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = "1.0"
 bincode = "1.3.3"
 ark-std = { version = "0.3.0", features = ["print-trace"], optional = true }
 
-halo2-base = { git = "https://github.com/axiom-crypto/halo2-lib.git", tag = "v0.2.2", default-features = false }
+halo2-base = { git = "https://github.com/scroll-tech/halo2-lib.git", branch = "halo2-ecc-snark-verifier-0323" }
 snark-verifier = { path = "../snark-verifier", default-features = false }
 
 # loader_evm
@@ -28,10 +28,10 @@ ethereum-types = { version = "0.14", default-features = false, features = ["std"
 # rlp = { version = "0.5", default-features = false, features = ["std"], optional = true }
 
 # zkevm benchmarks
-zkevm-circuits = { git = "https://github.com/jonathanpwang/zkevm-circuits.git", branch = "bench-12-04", features = ["test"], optional = true }
-bus-mapping = { git = "https://github.com/jonathanpwang/zkevm-circuits.git", branch = "bench-12-04", optional = true }
-eth-types = { git = "https://github.com/jonathanpwang/zkevm-circuits.git", branch = "bench-12-04", optional = true }
-mock = { git = "https://github.com/jonathanpwang/zkevm-circuits.git", branch = "bench-12-04", optional = true }
+zkevm-circuits = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "halo2-ecc-ecdsa-0323", features = ["test"], optional = true }
+bus-mapping = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "halo2-ecc-ecdsa-0323", optional = true }
+eth-types = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "halo2-ecc-ecdsa-0323", optional = true }
+mock = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "halo2-ecc-ecdsa-0323", optional = true }
 
 [dev-dependencies]
 ark-std = { version = "0.3.0", features = ["print-trace"] }
@@ -44,7 +44,7 @@ crossterm = { version = "0.25" }
 tui = { version = "0.19", default-features = false, features = ["crossterm"] }
 
 [features]
-default = ["loader_halo2", "loader_evm", "halo2-axiom", "halo2-base/jemallocator"]
+default = ["loader_halo2", "loader_evm", "halo2-pse", "halo2-base/jemallocator"]
 display = ["snark-verifier/display", "dep:ark-std"]
 loader_evm = ["snark-verifier/loader_evm", "dep:ethereum-types"]
 loader_halo2 = ["snark-verifier/loader_halo2"]

--- a/snark-verifier-sdk/Cargo.toml
+++ b/snark-verifier-sdk/Cargo.toml
@@ -28,10 +28,10 @@ ethereum-types = { version = "0.14", default-features = false, features = ["std"
 # rlp = { version = "0.5", default-features = false, features = ["std"], optional = true }
 
 # zkevm benchmarks
-zkevm-circuits = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "halo2-ecc-ecdsa-0323", features = ["test"], optional = true }
-bus-mapping = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "halo2-ecc-ecdsa-0323", optional = true }
-eth-types = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "halo2-ecc-ecdsa-0323", optional = true }
-mock = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "halo2-ecc-ecdsa-0323", optional = true }
+zkevm-circuits = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "halo2-ecc-snark-verifier-0323", features = ["test"], optional = true }
+bus-mapping = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "halo2-ecc-snark-verifier-0323", optional = true }
+eth-types = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "halo2-ecc-snark-verifier-0323", optional = true }
+mock = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "halo2-ecc-snark-verifier-0323", optional = true }
 
 [dev-dependencies]
 ark-std = { version = "0.3.0", features = ["print-trace"] }
@@ -44,7 +44,7 @@ crossterm = { version = "0.25" }
 tui = { version = "0.19", default-features = false, features = ["crossterm"] }
 
 [features]
-default = ["loader_halo2", "loader_evm", "halo2-pse", "halo2-base/jemallocator"]
+default = ["loader_halo2", "loader_evm", "halo2-pse", "halo2-base/jemallocator" ]
 display = ["snark-verifier/display", "dep:ark-std"]
 loader_evm = ["snark-verifier/loader_evm", "dep:ethereum-types"]
 loader_halo2 = ["snark-verifier/loader_halo2"]

--- a/snark-verifier-sdk/src/halo2/aggregation.rs
+++ b/snark-verifier-sdk/src/halo2/aggregation.rs
@@ -372,7 +372,7 @@ impl Circuit<Fr> for AggregationCircuit {
 
         // Expose instances
         for (i, cell) in instances.into_iter().enumerate() {
-            layouter.constrain_instance(cell, config.instance, i);
+            layouter.constrain_instance(cell, config.instance, i)?;
         }
         #[cfg(feature = "display")]
         end_timer!(witness_time);
@@ -510,7 +510,7 @@ impl Circuit<Fr> for PublicAggregationCircuit {
             .unwrap();
         // Expose instances
         for (i, cell) in instances.into_iter().enumerate() {
-            layouter.constrain_instance(cell, config.instance, i);
+            layouter.constrain_instance(cell, config.instance, i)?;
         }
         #[cfg(feature = "display")]
         end_timer!(witness_time);

--- a/snark-verifier-sdk/src/lib.rs
+++ b/snark-verifier-sdk/src/lib.rs
@@ -27,6 +27,9 @@ pub mod evm;
 #[cfg(feature = "loader_halo2")]
 pub mod halo2;
 
+#[cfg(test)]
+mod tests;
+
 pub const LIMBS: usize = 3;
 pub const BITS: usize = 88;
 

--- a/snark-verifier-sdk/src/tests/evm_verifier.rs
+++ b/snark-verifier-sdk/src/tests/evm_verifier.rs
@@ -1,0 +1,30 @@
+use super::StandardPlonk;
+use crate::evm::{evm_verify, gen_evm_proof_shplonk, gen_evm_verifier};
+use crate::gen_pk;
+use crate::CircuitExt;
+use ark_std::test_rng;
+use halo2_base::halo2_proofs;
+use halo2_proofs::halo2curves::bn256::Bn256;
+use snark_verifier::loader::halo2::halo2_ecc::halo2_base::utils::fs::gen_srs;
+use snark_verifier::pcs::kzg::{Bdfg21, Kzg};
+
+#[test]
+fn test_evm_verification() {
+    std::env::set_var("VERIFY_CONFIG", "./configs/verify_circuit.config");
+
+    let mut rng = test_rng();
+    let params = gen_srs(8);
+
+    let circuit = StandardPlonk::rand(&mut rng);
+    let pk = gen_pk(&params, &circuit, None);
+    let deployment_code = gen_evm_verifier::<StandardPlonk, Kzg<Bn256, Bdfg21>>(
+        &params,
+        pk.get_vk(),
+        circuit.num_instance(),
+        None,
+    );
+
+    let instances = circuit.instances();
+    let proof = gen_evm_proof_shplonk(&params, &pk, circuit.clone(), instances.clone(), &mut rng);
+    evm_verify(deployment_code.clone(), circuit.instances(), proof)
+}

--- a/snark-verifier-sdk/src/tests/mod.rs
+++ b/snark-verifier-sdk/src/tests/mod.rs
@@ -1,0 +1,115 @@
+use crate::CircuitExt;
+use halo2_base::halo2_proofs;
+use halo2_proofs::halo2curves::bn256::Fr;
+use halo2_proofs::{
+    circuit::{Layouter, SimpleFloorPlanner, Value},
+    plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Fixed, Instance},
+    poly::Rotation,
+};
+use rand::RngCore;
+
+mod evm_verifier;
+mod single_layer_aggregation;
+mod two_layer_aggregation;
+
+#[derive(Clone, Copy)]
+pub struct StandardPlonkConfig {
+    a: Column<Advice>,
+    b: Column<Advice>,
+    c: Column<Advice>,
+    q_a: Column<Fixed>,
+    q_b: Column<Fixed>,
+    q_c: Column<Fixed>,
+    q_ab: Column<Fixed>,
+    constant: Column<Fixed>,
+    #[allow(dead_code)]
+    instance: Column<Instance>,
+}
+
+impl StandardPlonkConfig {
+    fn configure(meta: &mut ConstraintSystem<Fr>) -> Self {
+        let [a, b, c] = [(); 3].map(|_| meta.advice_column());
+        let [q_a, q_b, q_c, q_ab, constant] = [(); 5].map(|_| meta.fixed_column());
+        let instance = meta.instance_column();
+
+        [a, b, c].map(|column| meta.enable_equality(column));
+
+        meta.create_gate(
+            "q_a·a + q_b·b + q_c·c + q_ab·a·b + constant + instance = 0",
+            |meta| {
+                let [a, b, c] = [a, b, c].map(|column| meta.query_advice(column, Rotation::cur()));
+                let [q_a, q_b, q_c, q_ab, constant] = [q_a, q_b, q_c, q_ab, constant]
+                    .map(|column| meta.query_fixed(column, Rotation::cur()));
+                let instance = meta.query_instance(instance, Rotation::cur());
+                Some(
+                    q_a * a.clone()
+                        + q_b * b.clone()
+                        + q_c * c
+                        + q_ab * a * b
+                        + constant
+                        + instance,
+                )
+            },
+        );
+
+        StandardPlonkConfig { a, b, c, q_a, q_b, q_c, q_ab, constant, instance }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct StandardPlonk(Fr);
+
+impl StandardPlonk {
+    pub fn rand<R: RngCore>(mut rng: R) -> Self {
+        Self(Fr::from(rng.next_u32() as u64))
+    }
+}
+
+impl CircuitExt<Fr> for StandardPlonk {
+    fn num_instance(&self) -> Vec<usize> {
+        vec![1]
+    }
+
+    fn instances(&self) -> Vec<Vec<Fr>> {
+        vec![vec![self.0]]
+    }
+}
+
+impl Circuit<Fr> for StandardPlonk {
+    type Config = StandardPlonkConfig;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self::default()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<Fr>) -> Self::Config {
+        meta.set_minimum_degree(4);
+        StandardPlonkConfig::configure(meta)
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<Fr>,
+    ) -> Result<(), Error> {
+        layouter.assign_region(
+            || "",
+            |mut region| {
+                region.assign_advice(|| "", config.a, 0, || Value::known(self.0))?;
+                region.assign_fixed(|| "", config.q_a, 0, || Value::known(-Fr::one()))?;
+                region.assign_advice(|| "", config.a, 1, || Value::known(-Fr::from(5u64)))?;
+                for (idx, column) in
+                    (1..).zip([config.q_a, config.q_b, config.q_c, config.q_ab, config.constant])
+                {
+                    region.assign_fixed(|| "", column, 1, || Value::known(Fr::from(idx as u64)))?;
+                }
+                let a = region.assign_advice(|| "", config.a, 2, || Value::known(Fr::one()))?;
+                a.copy_advice(|| "", &mut region, config.b, 3)?;
+                a.copy_advice(|| "", &mut region, config.c, 4)?;
+
+                Ok(())
+            },
+        )
+    }
+}

--- a/snark-verifier-sdk/src/tests/single_layer_aggregation.rs
+++ b/snark-verifier-sdk/src/tests/single_layer_aggregation.rs
@@ -1,0 +1,64 @@
+use super::StandardPlonk;
+use crate::evm::{evm_verify, gen_evm_proof_shplonk, gen_evm_verifier};
+use crate::halo2::aggregation::AggregationCircuit;
+use crate::CircuitExt;
+use crate::{gen_pk, halo2::gen_snark_shplonk};
+use ark_std::test_rng;
+use halo2_base::halo2_proofs;
+use halo2_proofs::halo2curves::bn256::Bn256;
+use halo2_proofs::poly::commitment::Params;
+use snark_verifier::loader::halo2::halo2_ecc::halo2_base::utils::fs::gen_srs;
+use snark_verifier::pcs::kzg::{Bdfg21, Kzg};
+use std::path::Path;
+#[test]
+fn test_aggregation_evm_verification() {
+    std::env::set_var("VERIFY_CONFIG", "./configs/example_evm_accumulator.config");
+    let k = 8;
+    let k_agg = 21;
+
+    let mut rng = test_rng();
+
+    let circuit = StandardPlonk::rand(&mut rng);
+    let params_outer = gen_srs(k_agg);
+    let params_inner = {
+        let mut params = params_outer.clone();
+        params.downsize(k);
+        params
+    };
+    let pk_inner = gen_pk(&params_inner, &circuit, Some(Path::new("data/inner.pkey")));
+    let snarks = (0..3)
+        .map(|i| {
+            gen_snark_shplonk(
+                &params_inner,
+                &pk_inner,
+                circuit.clone(),
+                &mut rng,
+                Some(Path::new(&format!("data/inner_{}.snark", i).to_string())),
+            )
+        })
+        .collect::<Vec<_>>();
+    println!("finished snark generation");
+
+    let agg_circuit = AggregationCircuit::new(&params_outer, snarks, &mut rng);
+    let pk_outer = gen_pk(&params_outer, &agg_circuit, Some(Path::new("data/outer.pkey")));
+    println!("finished outer pk generation");
+    let instances = agg_circuit.instances();
+    let proof = gen_evm_proof_shplonk(
+        &params_outer,
+        &pk_outer,
+        agg_circuit.clone(),
+        instances.clone(),
+        &mut rng,
+    );
+    println!("finished aggregation generation");
+
+    let deployment_code = gen_evm_verifier::<AggregationCircuit, Kzg<Bn256, Bdfg21>>(
+        &params_outer,
+        pk_outer.get_vk(),
+        agg_circuit.num_instance(),
+        Some(Path::new("data/single_layer_recur.sol")),
+    );
+
+    println!("finished bytecode generation");
+    evm_verify(deployment_code, instances, proof)
+}

--- a/snark-verifier-sdk/src/tests/two_layer_aggregation.rs
+++ b/snark-verifier-sdk/src/tests/two_layer_aggregation.rs
@@ -1,0 +1,76 @@
+use super::StandardPlonk;
+use crate::evm::{evm_verify, gen_evm_proof_shplonk, gen_evm_verifier};
+use crate::halo2::aggregation::AggregationCircuit;
+use crate::CircuitExt;
+use crate::{gen_pk, halo2::gen_snark_shplonk};
+use ark_std::test_rng;
+use halo2_base::halo2_proofs;
+use halo2_proofs::halo2curves::bn256::Bn256;
+use halo2_proofs::poly::commitment::Params;
+use snark_verifier::loader::halo2::halo2_ecc::halo2_base::utils::fs::gen_srs;
+use snark_verifier::pcs::kzg::{Bdfg21, Kzg};
+use std::path::Path;
+
+#[test]
+fn test_aggregation_evm_verification() {
+    std::env::set_var("VERIFY_CONFIG", "./configs/example_evm_accumulator.config");
+    let k = 8;
+    let k_agg = 21;
+
+    let mut rng = test_rng();
+    let params_outer = gen_srs(k_agg);
+    let params_inner = {
+        let mut params = params_outer.clone();
+        params.downsize(k);
+        params
+    };
+
+    // layer 1 snarks
+    let circuit = StandardPlonk::rand(&mut rng);
+    let pk_inner = gen_pk(&params_inner, &circuit, None);
+    let snarks = (0..3)
+        .map(|i| {
+            gen_snark_shplonk(
+                &params_inner,
+                &pk_inner,
+                circuit.clone(),
+                &mut rng,
+                Some(Path::new(&format!("data/inner_{}.snark", i).to_string())),
+            )
+        })
+        .collect::<Vec<_>>();
+    println!("finished snark generation");
+
+    // layer 2, first aggregation
+    let first_agg_circuit = AggregationCircuit::new(&params_outer, snarks, &mut rng);
+    let pk_outer = gen_pk(&params_outer, &first_agg_circuit, None);
+    println!("finished outer pk generation");
+    let first_agg_proof = gen_snark_shplonk(
+        &params_outer,
+        &pk_outer,
+        first_agg_circuit.clone(),
+        &mut rng,
+        Some(Path::new("data/outer.snark")),
+    );
+    println!("finished outer proof generation");
+
+    // layer 3, second aggregation
+    let second_agg_circuit = AggregationCircuit::new(&params_outer, [first_agg_proof], &mut rng);
+    let pk_agg = gen_pk(&params_outer, &second_agg_circuit, None);
+
+    let deployment_code = gen_evm_verifier::<AggregationCircuit, Kzg<Bn256, Bdfg21>>(
+        &params_outer,
+        pk_agg.get_vk(),
+        second_agg_circuit.num_instance(),
+        Some(Path::new("data/two_layer_recur.sol")),
+    );
+    let proof = gen_evm_proof_shplonk(
+        &params_outer,
+        &pk_agg,
+        second_agg_circuit.clone(),
+        second_agg_circuit.instances().clone(),
+        &mut rng,
+    );
+    println!("finished bytecode generation");
+    evm_verify(deployment_code, second_agg_circuit.instances(), proof)
+}

--- a/snark-verifier/Cargo.toml
+++ b/snark-verifier/Cargo.toml
@@ -15,7 +15,7 @@ rustc-hash = "1.1.0"
 serde = { version = "1.0", features = ["derive"] }
 
 # Use halo2-base as non-optional dependency because it re-exports halo2_proofs, halo2curves, and poseidon, using different repos based on feature flag "halo2-axiom" or "halo2-pse"
-halo2-base = { git = "https://github.com/axiom-crypto/halo2-lib.git", tag = "v0.2.2", default-features = false }
+halo2-base = { git = "https://github.com/scroll-tech/halo2-lib", branch = "halo2-ecc-snark-verifier-0323" }
 # This poseidon is identical to PSE (for now) but uses axiom's halo2curves; otherwise would require patching
 poseidon-axiom = { git = "https://github.com/axiom-crypto/halo2.git", branch = "axiom/faster-witness-generation", package = "poseidon", optional = true }
 poseidon= { git = "https://github.com/privacy-scaling-explorations/poseidon", optional = true }
@@ -31,7 +31,7 @@ bytes = { version = "1.2", optional = true }
 rlp = { version = "0.5", default-features = false, features = ["std"], optional = true }
 
 # loader_halo2
-halo2-ecc = { git = "https://github.com/axiom-crypto/halo2-lib.git", tag = "v0.2.2", default-features = false, optional = true }
+halo2-ecc = { git = "https://github.com/scroll-tech/halo2-lib", branch = "halo2-ecc-snark-verifier-0323", optional = true }
 
 [dev-dependencies]
 ark-std = { version = "0.3.0", features = ["print-trace"] }
@@ -44,7 +44,7 @@ crossterm = { version = "0.25" }
 tui = { version = "0.19", default-features = false, features = ["crossterm"] }
 
 [features]
-default = ["loader_evm", "loader_halo2", "halo2-axiom"]
+default = ["loader_evm", "loader_halo2", "halo2-pse"]
 display = ["halo2-base/display", "halo2-ecc?/display"]
 loader_evm = ["dep:ethereum-types", "dep:sha3", "dep:revm", "dep:bytes", "dep:rlp"]
 loader_halo2 = ["halo2-ecc"]

--- a/snark-verifier/examples/evm-verifier.rs
+++ b/snark-verifier/examples/evm-verifier.rs
@@ -1,18 +1,20 @@
 use ethereum_types::Address;
-use halo2_base::halo2_proofs;
+use halo2_base::halo2_proofs::{
+    self,
+    poly::kzg::multiopen::{ProverSHPLONK, VerifierSHPLONK},
+};
 use halo2_proofs::{
     circuit::{Layouter, SimpleFloorPlanner, Value},
     dev::MockProver,
     halo2curves::bn256::{Bn256, Fq, Fr, G1Affine},
     plonk::{
-        create_proof, keygen_pk, keygen_vk, verify_proof, Advice, Assigned, Circuit, Column,
+        create_proof, keygen_pk, keygen_vk, verify_proof, Advice, Circuit, Column,
         ConstraintSystem, Error, Fixed, Instance, ProvingKey, VerifyingKey,
     },
     poly::{
         commitment::{Params, ParamsProver},
         kzg::{
             commitment::{KZGCommitmentScheme, ParamsKZG},
-            multiopen::{ProverGWC, VerifierGWC},
             strategy::AccumulatorStrategy,
         },
         Rotation, VerificationStrategy,
@@ -23,13 +25,13 @@ use itertools::Itertools;
 use rand::{rngs::OsRng, RngCore};
 use snark_verifier::{
     loader::evm::{self, encode_calldata, EvmLoader, ExecutorBuilder},
-    pcs::kzg::{Gwc19, Kzg},
+    pcs::kzg::{Bdfg21, Kzg},
     system::halo2::{compile, transcript::evm::EvmTranscript, Config},
     verifier::{self, PlonkVerifier},
 };
 use std::rc::Rc;
 
-type Plonk = verifier::Plonk<Kzg<Bn256, Gwc19>>;
+type Plonk = verifier::Plonk<Kzg<Bn256, Bdfg21>>;
 
 #[derive(Clone, Copy)]
 struct StandardPlonkConfig {
@@ -192,22 +194,22 @@ fn gen_proof<C: Circuit<Fr>>(
     let instances = instances.iter().map(|instances| instances.as_slice()).collect_vec();
     let proof = {
         let mut transcript = TranscriptWriterBuffer::<_, G1Affine, _>::init(Vec::new());
-        create_proof::<KZGCommitmentScheme<Bn256>, ProverGWC<_>, _, _, EvmTranscript<_, _, _, _>, _>(
-            params,
-            pk,
-            &[circuit],
-            &[instances.as_slice()],
-            OsRng,
-            &mut transcript,
-        )
+        create_proof::<
+            KZGCommitmentScheme<Bn256>,
+            ProverSHPLONK<_>,
+            _,
+            _,
+            EvmTranscript<_, _, _, _>,
+            _,
+        >(params, pk, &[circuit], &[instances.as_slice()], OsRng, &mut transcript)
         .unwrap();
         transcript.finalize()
     };
 
     let accept = {
         let mut transcript = TranscriptReadBuffer::<_, G1Affine, _>::init(proof.as_slice());
-        VerificationStrategy::<_, VerifierGWC<_>>::finalize(
-            verify_proof::<_, VerifierGWC<_>, _, EvmTranscript<_, _, _, _>, _>(
+        VerificationStrategy::<_, VerifierSHPLONK<_>>::finalize(
+            verify_proof::<_, VerifierSHPLONK<_>, _, EvmTranscript<_, _, _, _>, _>(
                 params.verifier_params(),
                 pk.get_vk(),
                 AccumulatorStrategy::new(params.verifier_params()),
@@ -233,16 +235,25 @@ fn gen_evm_verifier(
 
     let loader = EvmLoader::new::<Fq, Fr>();
     let protocol = protocol.loaded(&loader);
+
     let mut transcript = EvmTranscript::<_, Rc<EvmLoader>, _, _>::new(&loader);
 
     let instances = transcript.load_instances(num_instance);
+
     let proof = Plonk::read_proof(&svk, &protocol, &instances, &mut transcript);
+
+    // println!("svk: {:?}", svk);
+    // println!("dk: {:?}", svk);
+    // println!("protocol {:?}", protocol);
+    // println!("instances: {:?}", instances);
+    // println!("proof {:?}", proof);
+
     Plonk::verify(&svk, &dk, &protocol, &instances, &proof);
 
     evm::compile_yul(&loader.yul_code())
 }
 
-fn evm_verify(deployment_code: Vec<u8>, instances: Vec<Vec<Fr>>, proof: Vec<u8>) {
+fn evm_verify(deployment_code: Vec<u8>, instances: Vec<Vec<Fr>>, proof: Vec<u8>) -> bool {
     let calldata = encode_calldata(&instances, &proof);
     let success = {
         let mut evm = ExecutorBuilder::default().with_gas_limit(u64::MAX.into()).build();
@@ -255,7 +266,7 @@ fn evm_verify(deployment_code: Vec<u8>, instances: Vec<Vec<Fr>>, proof: Vec<u8>)
 
         !result.reverted
     };
-    assert!(success);
+    success
 }
 
 fn main() {
@@ -266,5 +277,6 @@ fn main() {
     let deployment_code = gen_evm_verifier(&params, pk.get_vk(), StandardPlonk::num_instance());
 
     let proof = gen_proof(&params, &pk, circuit.clone(), circuit.instances());
-    evm_verify(deployment_code, circuit.instances(), proof);
+    let res = evm_verify(deployment_code.clone(), circuit.instances(), proof);
+    assert!(res)
 }

--- a/snark-verifier/src/system/halo2/test/kzg/halo2.rs
+++ b/snark-verifier/src/system/halo2/test/kzg/halo2.rs
@@ -154,7 +154,7 @@ pub fn accumulate<'a>(
         })
         .collect_vec();
 
-    let acccumulator = if accumulators.len() > 1 {
+    let accumulator = if accumulators.len() > 1 {
         let mut transcript = PoseidonTranscript::<Rc<Halo2Loader>, _>::new(loader, as_proof);
         let proof = As::read_proof(as_vk, &accumulators, &mut transcript).unwrap();
         As::verify(as_vk, &accumulators, &proof).unwrap()
@@ -162,7 +162,7 @@ pub fn accumulate<'a>(
         accumulators.pop().unwrap()
     };
 
-    acccumulator
+    accumulator
 }
 
 pub struct Accumulation {

--- a/snark-verifier/src/verifier/plonk.rs
+++ b/snark-verifier/src/verifier/plonk.rs
@@ -49,7 +49,7 @@ where
         let common_poly_eval = {
             let mut common_poly_eval = CommonPolynomialEvaluation::new(
                 &protocol.domain,
-                langranges(protocol, instances),
+                lagranges(protocol, instances),
                 &proof.z,
             );
 
@@ -383,7 +383,7 @@ where
     }
 }
 
-fn langranges<C, L>(
+fn lagranges<C, L>(
     protocol: &Protocol<C, L>,
     instances: &[Vec<L::LoadedScalar>],
 ) -> impl IntoIterator<Item = i32>


### PR DESCRIPTION
- sync up with halo2-dev-0220; use halo2-pse by default
- replacing GWC with SHPlonk in evm verifier -- GWC bytecode is still buggy and does not match the latest halo2-dev-0220
- add automated tests cases for
  - aggregating multiple proofs into a single proof
  - multi layer aggregations
   