### PR TITLE
fix: `rotate_scalar` misbehaves on `i32::MIN`

### DIFF
--- a/snark-verifier/src/util/arithmetic.rs
+++ b/snark-verifier/src/util/arithmetic.rs
@@ -150,7 +150,7 @@ impl<F: PrimeField> Domain<F> {
         match rotation.0.cmp(&0) {
             Ordering::Equal => scalar,
             Ordering::Greater => scalar * self.gen.pow_vartime([rotation.0 as u64]),
-            Ordering::Less => scalar * self.gen_inv.pow_vartime([(-rotation.0) as u64]),
+            Ordering::Less => scalar * self.gen_inv.pow_vartime([(-(rotation.0 as i64)) as u64]),
         }
     }
 }


### PR DESCRIPTION
Should never actually be callable with such a large negative rotation