### PR TITLE
[Feat] Universal verifier circuit

### DIFF
--- a/snark-verifier-sdk/benches/standard_plonk.rs
+++ b/snark-verifier-sdk/benches/standard_plonk.rs
@@ -209,6 +209,7 @@ fn bench(c: &mut Criterion) {
                     lookup_bits,
                     params,
                     snarks.clone(),
+                    false,
                 );
                 let instances = agg_circuit.instances();
                 gen_proof_shplonk(params, pk, agg_circuit, instances, None)
@@ -226,6 +227,7 @@ fn bench(c: &mut Criterion) {
             lookup_bits,
             &params,
             snarks.clone(),
+            false,
         );
         let num_instances = agg_circuit.num_instance();
         let instances = agg_circuit.instances();

--- a/snark-verifier-sdk/benches/standard_plonk.rs
+++ b/snark-verifier-sdk/benches/standard_plonk.rs
@@ -12,7 +12,7 @@ use halo2_proofs::{
 use pprof::criterion::{Output, PProfProfiler};
 use rand::rngs::OsRng;
 use snark_verifier_sdk::evm::{evm_verify, gen_evm_proof_shplonk, gen_evm_verifier_shplonk};
-use snark_verifier_sdk::halo2::aggregation::AggregationConfigParams;
+use snark_verifier_sdk::halo2::aggregation::{AggregationConfigParams, VerifierUniversality};
 use snark_verifier_sdk::{
     gen_pk,
     halo2::{aggregation::AggregationCircuit, gen_proof_shplonk, gen_snark_shplonk},
@@ -209,7 +209,7 @@ fn bench(c: &mut Criterion) {
                     lookup_bits,
                     params,
                     snarks.clone(),
-                    false,
+                    VerifierUniversality::None,
                 );
                 let instances = agg_circuit.instances();
                 gen_proof_shplonk(params, pk, agg_circuit, instances, None)
@@ -227,7 +227,7 @@ fn bench(c: &mut Criterion) {
             lookup_bits,
             &params,
             snarks.clone(),
-            false,
+            VerifierUniversality::None,
         );
         let num_instances = agg_circuit.num_instance();
         let instances = agg_circuit.instances();

--- a/snark-verifier-sdk/examples/standard_plonk.rs
+++ b/snark-verifier-sdk/examples/standard_plonk.rs
@@ -1,0 +1,210 @@
+use application::ComputeFlag;
+use ark_std::{end_timer, start_timer};
+use halo2_base::gates::builder::{set_lookup_bits, CircuitBuilderStage, BASE_CONFIG_PARAMS};
+use halo2_base::halo2_proofs;
+use halo2_base::halo2_proofs::arithmetic::Field;
+use halo2_base::halo2_proofs::halo2curves::bn256::Fr;
+use halo2_base::halo2_proofs::poly::commitment::Params;
+use halo2_base::utils::fs::gen_srs;
+use halo2_proofs::halo2curves as halo2_curves;
+use halo2_proofs::plonk::Circuit;
+use halo2_proofs::{halo2curves::bn256::Bn256, poly::kzg::commitment::ParamsKZG};
+use rand::rngs::OsRng;
+use snark_verifier_sdk::{
+    evm::{evm_verify, gen_evm_proof_shplonk, gen_evm_verifier_shplonk},
+    gen_pk,
+    halo2::{aggregation::AggregationCircuit, gen_snark_shplonk},
+    Snark,
+};
+use snark_verifier_sdk::{CircuitExt, SHPLONK};
+use std::path::Path;
+
+mod application {
+    use super::halo2_curves::bn256::Fr;
+    use super::halo2_proofs::{
+        circuit::{Layouter, SimpleFloorPlanner, Value},
+        plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Fixed, Instance},
+        poly::Rotation,
+    };
+    use rand::RngCore;
+    use snark_verifier_sdk::CircuitExt;
+
+    #[derive(Clone, Copy)]
+    pub struct StandardPlonkConfig {
+        a: Column<Advice>,
+        b: Column<Advice>,
+        c: Column<Advice>,
+        q_a: Column<Fixed>,
+        q_b: Column<Fixed>,
+        q_c: Column<Fixed>,
+        q_ab: Column<Fixed>,
+        constant: Column<Fixed>,
+        #[allow(dead_code)]
+        instance: Column<Instance>,
+    }
+
+    impl StandardPlonkConfig {
+        fn configure(meta: &mut ConstraintSystem<Fr>) -> Self {
+            let [a, b, c] = [(); 3].map(|_| meta.advice_column());
+            let [q_a, q_b, q_c, q_ab, constant] = [(); 5].map(|_| meta.fixed_column());
+            let instance = meta.instance_column();
+
+            [a, b, c].map(|column| meta.enable_equality(column));
+
+            meta.create_gate(
+                "q_a·a + q_b·b + q_c·c + q_ab·a·b + constant + instance = 0",
+                |meta| {
+                    let [a, b, c] =
+                        [a, b, c].map(|column| meta.query_advice(column, Rotation::cur()));
+                    let [q_a, q_b, q_c, q_ab, constant] = [q_a, q_b, q_c, q_ab, constant]
+                        .map(|column| meta.query_fixed(column, Rotation::cur()));
+                    let instance = meta.query_instance(instance, Rotation::cur());
+                    Some(
+                        q_a * a.clone()
+                            + q_b * b.clone()
+                            + q_c * c
+                            + q_ab * a * b
+                            + constant
+                            + instance,
+                    )
+                },
+            );
+
+            StandardPlonkConfig { a, b, c, q_a, q_b, q_c, q_ab, constant, instance }
+        }
+    }
+
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    pub enum ComputeFlag {
+        All,
+        SkipFixed,
+        SkipCopy,
+    }
+
+    #[derive(Clone)]
+    pub struct StandardPlonk(pub Fr, pub ComputeFlag);
+
+    impl CircuitExt<Fr> for StandardPlonk {
+        fn num_instance(&self) -> Vec<usize> {
+            vec![1]
+        }
+
+        fn instances(&self) -> Vec<Vec<Fr>> {
+            vec![vec![self.0]]
+        }
+    }
+
+    impl Circuit<Fr> for StandardPlonk {
+        type Config = StandardPlonkConfig;
+        type FloorPlanner = SimpleFloorPlanner;
+
+        fn without_witnesses(&self) -> Self {
+            Self(Fr::zero(), self.1)
+        }
+
+        fn configure(meta: &mut ConstraintSystem<Fr>) -> Self::Config {
+            meta.set_minimum_degree(4);
+            StandardPlonkConfig::configure(meta)
+        }
+
+        fn synthesize(
+            &self,
+            config: Self::Config,
+            mut layouter: impl Layouter<Fr>,
+        ) -> Result<(), Error> {
+            layouter.assign_region(
+                || "",
+                |mut region| {
+                    region.assign_advice(config.a, 0, Value::known(self.0));
+                    region.assign_fixed(config.q_a, 0, -Fr::one());
+                    region.assign_advice(config.a, 1, Value::known(-Fr::from(5u64)));
+                    if self.1 != ComputeFlag::SkipFixed {
+                        for (idx, column) in (1..).zip([
+                            config.q_a,
+                            config.q_b,
+                            config.q_c,
+                            config.q_ab,
+                            config.constant,
+                        ]) {
+                            region.assign_fixed(column, 1, Fr::from(idx as u64));
+                        }
+                    }
+                    let a = region.assign_advice(config.a, 2, Value::known(Fr::one()));
+                    if self.1 != ComputeFlag::SkipCopy {
+                        a.copy_advice(&mut region, config.b, 3);
+                        a.copy_advice(&mut region, config.c, 4);
+                    }
+
+                    Ok(())
+                },
+            )
+        }
+    }
+}
+
+fn gen_application_snark(params: &ParamsKZG<Bn256>, flag: ComputeFlag) -> Snark {
+    let circuit = application::StandardPlonk(Fr::random(OsRng), flag);
+
+    let pk = gen_pk(params, &circuit, None);
+    gen_snark_shplonk(params, &pk, circuit, None::<&str>)
+}
+
+fn main() {
+    let params_app = gen_srs(8);
+    let dummy_snark = gen_application_snark(&params_app, ComputeFlag::All);
+
+    let k = 22u32;
+    let params = gen_srs(k);
+    let lookup_bits = k as usize - 1;
+    BASE_CONFIG_PARAMS.with(|config| {
+        config.borrow_mut().lookup_bits = Some(lookup_bits);
+        config.borrow_mut().k = k as usize;
+    });
+    let agg_circuit = AggregationCircuit::new::<SHPLONK>(
+        CircuitBuilderStage::Keygen,
+        None,
+        lookup_bits,
+        &params,
+        vec![dummy_snark],
+        true,
+    );
+    agg_circuit.config(k, Some(10));
+
+    let start0 = start_timer!(|| "gen vk & pk");
+    let pk = gen_pk(&params, &agg_circuit, Some(Path::new("./examples/agg.pk")));
+    end_timer!(start0);
+    let break_points = agg_circuit.break_points();
+
+    let snarks = [ComputeFlag::All, ComputeFlag::SkipFixed, ComputeFlag::SkipCopy]
+        .map(|flag| gen_application_snark(&params_app, flag));
+    for (i, snark) in snarks.into_iter().enumerate() {
+        let agg_circuit = AggregationCircuit::new::<SHPLONK>(
+            CircuitBuilderStage::Prover,
+            Some(break_points.clone()),
+            lookup_bits,
+            &params,
+            vec![snark],
+            true,
+        );
+        let _snark = gen_snark_shplonk(&params, &pk, agg_circuit, None::<&str>);
+        println!("snark {i} success");
+    }
+
+    /*
+    #[cfg(feature = "loader_evm")]
+    {
+        // do one more time to verify
+        let num_instances = agg_circuit.num_instance();
+        let instances = agg_circuit.instances();
+        let proof_calldata = gen_evm_proof_shplonk(&params, &pk, agg_circuit, instances.clone());
+
+        let deployment_code = gen_evm_verifier_shplonk::<AggregationCircuit<SHPLONK>>(
+            &params,
+            pk.get_vk(),
+            num_instances,
+            Some(Path::new("./examples/standard_plonk.yul")),
+        );
+        evm_verify(deployment_code, instances, proof_calldata);
+    }
+    */
+}

--- a/snark-verifier-sdk/examples/vkey_as_witness.rs
+++ b/snark-verifier-sdk/examples/vkey_as_witness.rs
@@ -1,23 +1,20 @@
 use application::ComputeFlag;
-use ark_std::{end_timer, start_timer};
-use halo2_base::gates::builder::{set_lookup_bits, CircuitBuilderStage, BASE_CONFIG_PARAMS};
+
+use halo2_base::gates::builder::{CircuitBuilderStage, BASE_CONFIG_PARAMS};
 use halo2_base::halo2_proofs;
 use halo2_base::halo2_proofs::arithmetic::Field;
 use halo2_base::halo2_proofs::halo2curves::bn256::Fr;
-use halo2_base::halo2_proofs::poly::commitment::Params;
 use halo2_base::utils::fs::gen_srs;
 use halo2_proofs::halo2curves as halo2_curves;
-use halo2_proofs::plonk::Circuit;
+
 use halo2_proofs::{halo2curves::bn256::Bn256, poly::kzg::commitment::ParamsKZG};
 use rand::rngs::OsRng;
+use snark_verifier_sdk::SHPLONK;
 use snark_verifier_sdk::{
-    evm::{evm_verify, gen_evm_proof_shplonk, gen_evm_verifier_shplonk},
     gen_pk,
     halo2::{aggregation::AggregationCircuit, gen_snark_shplonk},
     Snark,
 };
-use snark_verifier_sdk::{CircuitExt, SHPLONK};
-use std::path::Path;
 
 mod application {
     use super::halo2_curves::bn256::Fr;
@@ -26,7 +23,7 @@ mod application {
         plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Fixed, Instance},
         poly::Rotation,
     };
-    use rand::RngCore;
+
     use snark_verifier_sdk::CircuitExt;
 
     #[derive(Clone, Copy)]

--- a/snark-verifier-sdk/examples/vkey_as_witness.rs
+++ b/snark-verifier-sdk/examples/vkey_as_witness.rs
@@ -153,7 +153,7 @@ fn main() {
     let params_app = gen_srs(8);
     let dummy_snark = gen_application_snark(&params_app, ComputeFlag::All);
 
-    let k = 22u32;
+    let k = 15u32;
     let params = gen_srs(k);
     let lookup_bits = k as usize - 1;
     BASE_CONFIG_PARAMS.with(|config| {
@@ -170,9 +170,7 @@ fn main() {
     );
     agg_circuit.config(k, Some(10));
 
-    let start0 = start_timer!(|| "gen vk & pk");
-    let pk = gen_pk(&params, &agg_circuit, Some(Path::new("./examples/agg.pk")));
-    end_timer!(start0);
+    let pk = gen_pk(&params, &agg_circuit, None);
     let break_points = agg_circuit.break_points();
 
     let snarks = [ComputeFlag::All, ComputeFlag::SkipFixed, ComputeFlag::SkipCopy]
@@ -189,22 +187,4 @@ fn main() {
         let _snark = gen_snark_shplonk(&params, &pk, agg_circuit, None::<&str>);
         println!("snark {i} success");
     }
-
-    /*
-    #[cfg(feature = "loader_evm")]
-    {
-        // do one more time to verify
-        let num_instances = agg_circuit.num_instance();
-        let instances = agg_circuit.instances();
-        let proof_calldata = gen_evm_proof_shplonk(&params, &pk, agg_circuit, instances.clone());
-
-        let deployment_code = gen_evm_verifier_shplonk::<AggregationCircuit<SHPLONK>>(
-            &params,
-            pk.get_vk(),
-            num_instances,
-            Some(Path::new("./examples/standard_plonk.yul")),
-        );
-        evm_verify(deployment_code, instances, proof_calldata);
-    }
-    */
 }

--- a/snark-verifier/examples/recursion.rs
+++ b/snark-verifier/examples/recursion.rs
@@ -358,7 +358,7 @@ mod recursion {
     ) -> (Vec<Vec<AssignedValue<Fr>>>, Vec<KzgAccumulator<G1Affine, Rc<Halo2Loader<'a>>>>) {
         let protocol = if let Some(preprocessed_digest) = preprocessed_digest {
             let preprocessed_digest = loader.scalar_from_assigned(preprocessed_digest);
-            let protocol = snark.protocol.loaded_preprocessed_as_witness(loader);
+            let protocol = snark.protocol.loaded_preprocessed_as_witness(loader, false);
             let inputs = protocol
                 .preprocessed
                 .iter()

--- a/snark-verifier/src/loader.rs
+++ b/snark-verifier/src/loader.rs
@@ -67,6 +67,12 @@ pub trait LoadedScalar<F: PrimeField>: Clone + Debug + PartialEq + FieldOps {
         acc
     }
 
+    /// Returns power to exponent, where exponent is also [`LoadedScalar`].
+    /// If `Loader` is for Halo2, then `exp` must have at most `exp_max_bits` bits (otherwise constraints will fail).
+    ///
+    /// Currently **unimplemented** for EvmLoader
+    fn pow_var(&self, exp: &Self, exp_max_bits: usize) -> Self;
+
     /// Returns powers up to exponent `n-1`.
     fn powers(&self, n: usize) -> Vec<Self> {
         iter::once(self.loader().load_one())

--- a/snark-verifier/src/loader/evm/loader.rs
+++ b/snark-verifier/src/loader/evm/loader.rs
@@ -632,6 +632,10 @@ impl<F: PrimeField<Repr = [u8; 0x20]>> LoadedScalar<F> for Scalar {
     fn loader(&self) -> &Self::Loader {
         &self.loader
     }
+
+    fn pow_var(&self, _exp: &Self, _exp_max_bits: usize) -> Self {
+        todo!()
+    }
 }
 
 impl<C> EcPointLoader<C> for Rc<EvmLoader>

--- a/snark-verifier/src/loader/halo2/loader.rs
+++ b/snark-verifier/src/loader/halo2/loader.rs
@@ -306,6 +306,17 @@ impl<C: CurveAffine, EccChip: EccInstructions<C>> LoadedScalar<C::Scalar> for Sc
     fn loader(&self) -> &Self::Loader {
         &self.loader
     }
+
+    fn pow_var(&self, exp: &Self, max_bits: usize) -> Self {
+        let loader = self.loader();
+        let res = loader.scalar_chip().pow_var(
+            &mut loader.ctx_mut(),
+            &self.assigned(),
+            &exp.assigned(),
+            max_bits,
+        );
+        loader.scalar_from_assigned(res)
+    }
 }
 
 impl<C: CurveAffine, EccChip: EccInstructions<C>> Debug for Scalar<C, EccChip> {

--- a/snark-verifier/src/loader/halo2/loader.rs
+++ b/snark-verifier/src/loader/halo2/loader.rs
@@ -309,12 +309,9 @@ impl<C: CurveAffine, EccChip: EccInstructions<C>> LoadedScalar<C::Scalar> for Sc
 
     fn pow_var(&self, exp: &Self, max_bits: usize) -> Self {
         let loader = self.loader();
-        let res = loader.scalar_chip().pow_var(
-            &mut loader.ctx_mut(),
-            &self.assigned(),
-            &exp.assigned(),
-            max_bits,
-        );
+        let base = self.clone().into_assigned();
+        let exp = exp.clone().into_assigned();
+        let res = loader.scalar_chip().pow_var(&mut loader.ctx_mut(), &base, &exp, max_bits);
         loader.scalar_from_assigned(res)
     }
 }

--- a/snark-verifier/src/loader/halo2/shim.rs
+++ b/snark-verifier/src/loader/halo2/shim.rs
@@ -65,6 +65,15 @@ pub trait IntegerInstructions<F: FieldExt>: Clone + Debug {
         lhs: &Self::AssignedInteger,
         rhs: &Self::AssignedInteger,
     );
+
+    /// Returns `base^exponent` and constrains that `exponent` has at most `max_bits` bits.
+    fn pow_var(
+        &self,
+        ctx: &mut Self::Context,
+        base: &Self::AssignedInteger,
+        exponent: &Self::AssignedInteger,
+        max_bits: usize,
+    ) -> Self::AssignedInteger;
 }
 
 /// Instructions to handle elliptic curve point operations.
@@ -231,6 +240,16 @@ mod halo2_lib {
             b: &Self::AssignedInteger,
         ) {
             ctx.main(0).constrain_equal(a, b);
+        }
+
+        fn pow_var(
+            &self,
+            ctx: &mut Self::Context,
+            base: &Self::AssignedInteger,
+            exponent: &Self::AssignedInteger,
+            max_bits: usize,
+        ) -> Self::AssignedInteger {
+            GateInstructions::pow_var(self, ctx.main(0), *base, *exponent, max_bits)
         }
     }
 

--- a/snark-verifier/src/loader/native.rs
+++ b/snark-verifier/src/loader/native.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     loader::{EcPointLoader, LoadedEcPoint, LoadedScalar, Loader, ScalarLoader},
-    util::arithmetic::{Curve, CurveAffine, FieldOps, PrimeField},
+    util::arithmetic::{fe_to_big, Curve, CurveAffine, FieldOps, PrimeField},
     Error,
 };
 use lazy_static::lazy_static;
@@ -37,6 +37,11 @@ impl<F: PrimeField> LoadedScalar<F> for F {
 
     fn loader(&self) -> &NativeLoader {
         &LOADER
+    }
+
+    fn pow_var(&self, exp: &Self, _: usize) -> Self {
+        let exp = fe_to_big(*exp).to_u64_digits();
+        self.pow_vartime(exp)
     }
 }
 

--- a/snark-verifier/src/pcs/ipa/multiopen/bgh19.rs
+++ b/snark-verifier/src/pcs/ipa/multiopen/bgh19.rs
@@ -5,7 +5,7 @@ use crate::{
         PolynomialCommitmentScheme, Query,
     },
     util::{
-        arithmetic::{CurveAffine, FieldExt, Fraction},
+        arithmetic::{CurveAffine, FieldExt, Fraction, Rotation},
         msm::Msm,
         transcript::TranscriptRead,
         Itertools,
@@ -35,7 +35,7 @@ where
 
     fn read_proof<T>(
         svk: &Self::VerifyingKey,
-        queries: &[Query<C::Scalar>],
+        queries: &[Query<Rotation>],
         transcript: &mut T,
     ) -> Result<Self::Proof, Error>
     where
@@ -48,7 +48,7 @@ where
         svk: &Self::VerifyingKey,
         commitments: &[Msm<C, L>],
         x: &L::LoadedScalar,
-        queries: &[Query<C::Scalar, L::LoadedScalar>],
+        queries: &[Query<Rotation, L::LoadedScalar>],
         proof: &Self::Proof,
     ) -> Result<Self::Output, Error> {
         let loader = x.loader();
@@ -119,7 +119,7 @@ where
 {
     fn read<T: TranscriptRead<C, L>>(
         svk: &IpaSuccinctVerifyingKey<C>,
-        queries: &[Query<C::Scalar>],
+        queries: &[Query<Rotation>],
         transcript: &mut T,
     ) -> Result<Self, Error> {
         // Multiopen
@@ -157,28 +157,33 @@ where
     }
 }
 
-fn query_sets<F, T>(queries: &[Query<F, T>]) -> Vec<QuerySet<F, T>>
+fn query_sets<S, T>(queries: &[Query<S, T>]) -> Vec<QuerySet<S, T>>
 where
-    F: FieldExt,
+    S: PartialEq + Ord + Copy,
     T: Clone,
 {
     let poly_shifts =
-        queries.iter().fold(Vec::<(usize, Vec<F>, Vec<&T>)>::new(), |mut poly_shifts, query| {
+        queries.iter().fold(Vec::<(usize, Vec<_>, Vec<&T>)>::new(), |mut poly_shifts, query| {
             if let Some(pos) = poly_shifts.iter().position(|(poly, _, _)| *poly == query.poly) {
                 let (_, shifts, evals) = &mut poly_shifts[pos];
-                if !shifts.contains(&query.shift) {
-                    shifts.push(query.shift);
+                if !shifts.iter().map(|(shift, _)| shift).contains(&query.shift) {
+                    shifts.push((query.shift, query.loaded_shift.clone()));
                     evals.push(&query.eval);
                 }
             } else {
-                poly_shifts.push((query.poly, vec![query.shift], vec![&query.eval]));
+                poly_shifts.push((
+                    query.poly,
+                    vec![(query.shift, query.loaded_shift.clone())],
+                    vec![&query.eval],
+                ));
             }
             poly_shifts
         });
 
-    poly_shifts.into_iter().fold(Vec::<QuerySet<F, T>>::new(), |mut sets, (poly, shifts, evals)| {
+    poly_shifts.into_iter().fold(Vec::<QuerySet<_, T>>::new(), |mut sets, (poly, shifts, evals)| {
         if let Some(pos) = sets.iter().position(|set| {
-            BTreeSet::from_iter(set.shifts.iter()) == BTreeSet::from_iter(shifts.iter())
+            BTreeSet::from_iter(set.shifts.iter().map(|(shift, _)| shift))
+                == BTreeSet::from_iter(shifts.iter().map(|(shift, _)| shift))
         }) {
             let set = &mut sets[pos];
             if !set.polys.contains(&poly) {
@@ -187,7 +192,7 @@ where
                     set.shifts
                         .iter()
                         .map(|lhs| {
-                            let idx = shifts.iter().position(|rhs| lhs == rhs).unwrap();
+                            let idx = shifts.iter().position(|rhs| lhs.0 == rhs.0).unwrap();
                             evals[idx]
                         })
                         .collect(),
@@ -201,18 +206,23 @@ where
     })
 }
 
-fn query_set_coeffs<F, T>(sets: &[QuerySet<F, T>], x: &T, x_3: &T) -> Vec<QuerySetCoeff<F, T>>
+fn query_set_coeffs<F, T>(
+    sets: &[QuerySet<Rotation, T>],
+    x: &T,
+    x_3: &T,
+) -> Vec<QuerySetCoeff<F, T>>
 where
     F: FieldExt,
     T: LoadedScalar<F>,
 {
-    let loader = x.loader();
-    let superset = sets.iter().flat_map(|set| set.shifts.clone()).sorted().dedup();
+    let superset = BTreeMap::from_iter(sets.iter().flat_map(|set| set.shifts.clone()));
 
     let size = sets.iter().map(|set| set.shifts.len()).chain(Some(2)).max().unwrap();
     let powers_of_x = x.powers(size);
     let x_3_minus_x_shift_i = BTreeMap::from_iter(
-        superset.map(|shift| (shift, x_3.clone() - x.clone() * loader.load_const(&shift))),
+        superset
+            .into_iter()
+            .map(|(shift, loaded_shift)| (shift, x_3.clone() - x.clone() * loaded_shift)),
     );
 
     let mut coeffs = sets
@@ -228,23 +238,22 @@ where
 }
 
 #[derive(Clone, Debug)]
-struct QuerySet<'a, F, T> {
-    shifts: Vec<F>,
+struct QuerySet<'a, S, T> {
+    shifts: Vec<(S, T)>,
     polys: Vec<usize>,
     evals: Vec<Vec<&'a T>>,
 }
 
-impl<'a, F, T> QuerySet<'a, F, T>
-where
-    F: FieldExt,
-    T: LoadedScalar<F>,
-{
+impl<'a, S, T> QuerySet<'a, S, T> {
     fn msm<C: CurveAffine, L: Loader<C, LoadedScalar = T>>(
         &self,
         commitments: &[Msm<'a, C, L>],
         q_eval: &T,
         powers_of_x_1: &[T],
-    ) -> Msm<C, L> {
+    ) -> Msm<C, L>
+    where
+        T: LoadedScalar<C::Scalar>,
+    {
         self.polys
             .iter()
             .rev()
@@ -254,7 +263,10 @@ where
             - Msm::constant(q_eval.clone())
     }
 
-    fn f_eval(&self, coeff: &QuerySetCoeff<F, T>, q_eval: &T, powers_of_x_1: &[T]) -> T {
+    fn f_eval<F: FieldExt>(&self, coeff: &QuerySetCoeff<F, T>, q_eval: &T, powers_of_x_1: &[T]) -> T
+    where
+        T: LoadedScalar<F>,
+    {
         let loader = q_eval.loader();
         let r_eval = {
             let r_evals = self
@@ -291,7 +303,12 @@ where
     F: FieldExt,
     T: LoadedScalar<F>,
 {
-    fn new(shifts: &[F], powers_of_x: &[T], x_3: &T, x_3_minus_x_shift_i: &BTreeMap<F, T>) -> Self {
+    fn new(
+        shifts: &[(Rotation, T)],
+        powers_of_x: &[T],
+        x_3: &T,
+        x_3_minus_x_shift_i: &BTreeMap<Rotation, T>,
+    ) -> Self {
         let loader = x_3.loader();
         let normalized_ell_primes = shifts
             .iter()
@@ -301,9 +318,9 @@ where
                     .iter()
                     .enumerate()
                     .filter(|&(i, _)| i != j)
-                    .map(|(_, shift_i)| (*shift_j - shift_i))
+                    .map(|(_, shift_i)| (shift_j.1.clone() - &shift_i.1))
                     .reduce(|acc, value| acc * value)
-                    .unwrap_or_else(|| F::one())
+                    .unwrap_or_else(|| loader.load_const(&F::one()))
             })
             .collect_vec();
 
@@ -313,17 +330,15 @@ where
         let barycentric_weights = shifts
             .iter()
             .zip(normalized_ell_primes.iter())
-            .map(|(shift, normalized_ell_prime)| {
-                loader.sum_products_with_coeff(&[
-                    (*normalized_ell_prime, x_pow_k_minus_one, x_3),
-                    (-(*normalized_ell_prime * shift), x_pow_k_minus_one, x),
-                ])
+            .map(|((_, loaded_shift), normalized_ell_prime)| {
+                let tmp = normalized_ell_prime.clone() * x_pow_k_minus_one;
+                loader.sum_products(&[(&tmp, x_3), (&-(tmp.clone() * loaded_shift), x)])
             })
             .map(Fraction::one_over)
             .collect_vec();
 
         let f_eval_coeff = Fraction::one_over(loader.product(
-            &shifts.iter().map(|shift| x_3_minus_x_shift_i.get(shift).unwrap()).collect_vec(),
+            &shifts.iter().map(|(shift, _)| x_3_minus_x_shift_i.get(shift).unwrap()).collect_vec(),
         ));
 
         Self {

--- a/snark-verifier/src/pcs/kzg/multiopen/bdfg21.rs
+++ b/snark-verifier/src/pcs/kzg/multiopen/bdfg21.rs
@@ -6,7 +6,7 @@ use crate::{
         PolynomialCommitmentScheme, Query,
     },
     util::{
-        arithmetic::{CurveAffine, FieldExt, Fraction, MultiMillerLoop},
+        arithmetic::{CurveAffine, FieldExt, Fraction, MultiMillerLoop, Rotation},
         msm::Msm,
         transcript::TranscriptRead,
         Itertools,
@@ -35,7 +35,7 @@ where
 
     fn read_proof<T>(
         _: &KzgSuccinctVerifyingKey<M::G1Affine>,
-        _: &[Query<M::Scalar>],
+        _: &[Query<Rotation>],
         transcript: &mut T,
     ) -> Result<Bdfg21Proof<M::G1Affine, L>, Error>
     where
@@ -48,16 +48,15 @@ where
         svk: &KzgSuccinctVerifyingKey<M::G1Affine>,
         commitments: &[Msm<M::G1Affine, L>],
         z: &L::LoadedScalar,
-        queries: &[Query<M::Scalar, L::LoadedScalar>],
+        queries: &[Query<Rotation, L::LoadedScalar>],
         proof: &Bdfg21Proof<M::G1Affine, L>,
     ) -> Result<Self::Output, Error> {
         let sets = query_sets(queries);
         let f = {
             let coeffs = query_set_coeffs(&sets, z, &proof.z_prime);
 
-            let powers_of_mu = proof
-                .mu
-                .powers(sets.iter().map(|set| set.polys.len()).max().unwrap());
+            let powers_of_mu =
+                proof.mu.powers(sets.iter().map(|set| set.polys.len()).max().unwrap());
             let msms = sets
                 .iter()
                 .zip(coeffs.iter())
@@ -72,10 +71,7 @@ where
         let rhs = Msm::base(&proof.w_prime);
         let lhs = f + rhs.clone() * &proof.z_prime;
 
-        Ok(KzgAccumulator::new(
-            lhs.evaluate(Some(svk.g)),
-            rhs.evaluate(Some(svk.g)),
-        ))
+        Ok(KzgAccumulator::new(lhs.evaluate(Some(svk.g)), rhs.evaluate(Some(svk.g))))
     }
 }
 
@@ -104,94 +100,71 @@ where
         let w = transcript.read_ec_point()?;
         let z_prime = transcript.squeeze_challenge();
         let w_prime = transcript.read_ec_point()?;
-        Ok(Bdfg21Proof {
-            mu,
-            gamma,
-            w,
-            z_prime,
-            w_prime,
-        })
+        Ok(Bdfg21Proof { mu, gamma, w, z_prime, w_prime })
     }
 }
 
-fn query_sets<F: FieldExt, T: Clone>(queries: &[Query<F, T>]) -> Vec<QuerySet<F, T>> {
-    let poly_shifts = queries.iter().fold(
-        Vec::<(usize, Vec<F>, Vec<&T>)>::new(),
-        |mut poly_shifts, query| {
-            if let Some(pos) = poly_shifts
-                .iter()
-                .position(|(poly, _, _)| *poly == query.poly)
-            {
+fn query_sets<S: PartialEq + Ord + Copy, T: Clone>(queries: &[Query<S, T>]) -> Vec<QuerySet<S, T>> {
+    let poly_shifts =
+        queries.iter().fold(Vec::<(usize, Vec<_>, Vec<&T>)>::new(), |mut poly_shifts, query| {
+            if let Some(pos) = poly_shifts.iter().position(|(poly, _, _)| *poly == query.poly) {
                 let (_, shifts, evals) = &mut poly_shifts[pos];
-                if !shifts.contains(&query.shift) {
-                    shifts.push(query.shift);
+                if !shifts.iter().map(|(shift, _)| shift).contains(&query.shift) {
+                    shifts.push((query.shift, query.loaded_shift.clone()));
                     evals.push(&query.eval);
                 }
             } else {
-                poly_shifts.push((query.poly, vec![query.shift], vec![&query.eval]));
+                poly_shifts.push((
+                    query.poly,
+                    vec![(query.shift, query.loaded_shift.clone())],
+                    vec![&query.eval],
+                ));
             }
             poly_shifts
-        },
-    );
+        });
 
-    poly_shifts.into_iter().fold(
-        Vec::<QuerySet<F, T>>::new(),
-        |mut sets, (poly, shifts, evals)| {
-            if let Some(pos) = sets.iter().position(|set| {
-                BTreeSet::from_iter(set.shifts.iter()) == BTreeSet::from_iter(shifts.iter())
-            }) {
-                let set = &mut sets[pos];
-                if !set.polys.contains(&poly) {
-                    set.polys.push(poly);
-                    set.evals.push(
-                        set.shifts
-                            .iter()
-                            .map(|lhs| {
-                                let idx = shifts.iter().position(|rhs| lhs == rhs).unwrap();
-                                evals[idx]
-                            })
-                            .collect(),
-                    );
-                }
-            } else {
-                let set = QuerySet {
-                    shifts,
-                    polys: vec![poly],
-                    evals: vec![evals],
-                };
-                sets.push(set);
+    poly_shifts.into_iter().fold(Vec::<QuerySet<_, T>>::new(), |mut sets, (poly, shifts, evals)| {
+        if let Some(pos) = sets.iter().position(|set| {
+            BTreeSet::from_iter(set.shifts.iter().map(|(shift, _)| shift))
+                == BTreeSet::from_iter(shifts.iter().map(|(shift, _)| shift))
+        }) {
+            let set = &mut sets[pos];
+            if !set.polys.contains(&poly) {
+                set.polys.push(poly);
+                set.evals.push(
+                    set.shifts
+                        .iter()
+                        .map(|lhs| {
+                            let idx = shifts.iter().position(|rhs| lhs.0 == rhs.0).unwrap();
+                            evals[idx]
+                        })
+                        .collect(),
+                );
             }
-            sets
-        },
-    )
+        } else {
+            let set = QuerySet { shifts, polys: vec![poly], evals: vec![evals] };
+            sets.push(set);
+        }
+        sets
+    })
 }
 
 fn query_set_coeffs<'a, F: FieldExt, T: LoadedScalar<F>>(
-    sets: &[QuerySet<'a, F, T>],
+    sets: &[QuerySet<'a, Rotation, T>],
     z: &T,
     z_prime: &T,
 ) -> Vec<QuerySetCoeff<F, T>> {
-    let loader = z.loader();
+    // map of shift => loaded_shift, removing duplicate `shift` values
+    // shift is the rotation, not omega^rotation, to ensure BTreeMap does not depend on omega (otherwise ordering can change)
+    let superset = BTreeMap::from_iter(sets.iter().flat_map(|set| set.shifts.clone()));
 
-    let superset = sets
-        .iter()
-        .flat_map(|set| set.shifts.clone())
-        .sorted()
-        .dedup();
-
-    let size = sets
-        .iter()
-        .map(|set| set.shifts.len())
-        .chain(Some(2))
-        .max()
-        .unwrap();
+    let size = sets.iter().map(|set| set.shifts.len()).chain(Some(2)).max().unwrap();
     let powers_of_z = z.powers(size);
-    let z_prime_minus_z_shift_i = BTreeMap::from_iter(superset.map(|shift| {
-        (
-            shift,
-            z_prime.clone() - z.clone() * loader.load_const(&shift),
-        )
-    }));
+    let z_prime_minus_z_shift_i = BTreeMap::from_iter(
+        superset
+            .into_iter()
+            .map(|(shift, loaded_shift)| (shift, z_prime.clone() - z.clone() * loaded_shift)),
+    );
 
     let mut z_s_1 = None;
     let mut coeffs = sets
@@ -219,19 +192,22 @@ fn query_set_coeffs<'a, F: FieldExt, T: LoadedScalar<F>>(
 }
 
 #[derive(Clone, Debug)]
-struct QuerySet<'a, F, T> {
-    shifts: Vec<F>,
+struct QuerySet<'a, S, T> {
+    shifts: Vec<(S, T)>, // vec of (shift, loaded_shift)
     polys: Vec<usize>,
     evals: Vec<Vec<&'a T>>,
 }
 
-impl<'a, F: FieldExt, T: LoadedScalar<F>> QuerySet<'a, F, T> {
+impl<'a, S, T> QuerySet<'a, S, T> {
     fn msm<C: CurveAffine, L: Loader<C, LoadedScalar = T>>(
         &self,
-        coeff: &QuerySetCoeff<F, T>,
+        coeff: &QuerySetCoeff<C::Scalar, T>,
         commitments: &[Msm<'a, C, L>],
         powers_of_mu: &[T],
-    ) -> Msm<C, L> {
+    ) -> Msm<C, L>
+    where
+        T: LoadedScalar<C::Scalar>,
+    {
         self.polys
             .iter()
             .zip(self.evals.iter())
@@ -274,10 +250,10 @@ where
     T: LoadedScalar<F>,
 {
     fn new(
-        shifts: &[F],
+        shifts: &[(Rotation, T)],
         powers_of_z: &[T],
         z_prime: &T,
-        z_prime_minus_z_shift_i: &BTreeMap<F, T>,
+        z_prime_minus_z_shift_i: &BTreeMap<Rotation, T>,
         z_s_1: &Option<T>,
     ) -> Self {
         let loader = z_prime.loader();
@@ -290,9 +266,9 @@ where
                     .iter()
                     .enumerate()
                     .filter(|&(i, _)| i != j)
-                    .map(|(_, shift_i)| (*shift_j - shift_i))
+                    .map(|(_, shift_i)| (shift_j.1.clone() - &shift_i.1))
                     .reduce(|acc, value| acc * value)
-                    .unwrap_or_else(|| F::one())
+                    .unwrap_or_else(|| loader.load_const(&F::one()))
             })
             .collect_vec();
 
@@ -302,11 +278,9 @@ where
         let barycentric_weights = shifts
             .iter()
             .zip(normalized_ell_primes.iter())
-            .map(|(shift, normalized_ell_prime)| {
-                loader.sum_products_with_coeff(&[
-                    (*normalized_ell_prime, z_pow_k_minus_one, z_prime),
-                    (-(*normalized_ell_prime * shift), z_pow_k_minus_one, z),
-                ])
+            .map(|((_, loaded_shift), normalized_ell_prime)| {
+                let tmp = normalized_ell_prime.clone() * z_pow_k_minus_one;
+                loader.sum_products(&[(&tmp, z_prime), (&-(tmp.clone() * loaded_shift), z)])
             })
             .map(Fraction::one_over)
             .collect_vec();
@@ -314,7 +288,7 @@ where
         let z_s = loader.product(
             &shifts
                 .iter()
-                .map(|shift| z_prime_minus_z_shift_i.get(shift).unwrap())
+                .map(|(shift, _)| z_prime_minus_z_shift_i.get(shift).unwrap())
                 .collect_vec(),
         );
         let z_s_1_over_z_s = z_s_1.clone().map(|z_s_1| Fraction::new(z_s_1, z_s.clone()));
@@ -344,13 +318,8 @@ where
                 .iter_mut()
                 .chain(self.commitment_coeff.as_mut())
                 .for_each(Fraction::evaluate);
-            let barycentric_weights_sum = loader.sum(
-                &self
-                    .eval_coeffs
-                    .iter()
-                    .map(Fraction::evaluated)
-                    .collect_vec(),
-            );
+            let barycentric_weights_sum =
+                loader.sum(&self.eval_coeffs.iter().map(Fraction::evaluated).collect_vec());
             self.r_eval_coeff = Some(match self.commitment_coeff.as_ref() {
                 Some(coeff) => Fraction::new(coeff.evaluated().clone(), barycentric_weights_sum),
                 None => Fraction::one_over(barycentric_weights_sum),
@@ -370,13 +339,9 @@ impl<M> CostEstimation<M::G1Affine> for KzgAs<M, Bdfg21>
 where
     M: MultiMillerLoop,
 {
-    type Input = Vec<Query<M::Scalar>>;
+    type Input = Vec<Query<Rotation>>;
 
-    fn estimate_cost(_: &Vec<Query<M::Scalar>>) -> Cost {
-        Cost {
-            num_commitment: 2,
-            num_msm: 2,
-            ..Default::default()
-        }
+    fn estimate_cost(_: &Vec<Query<Rotation>>) -> Cost {
+        Cost { num_commitment: 2, num_msm: 2, ..Default::default() }
     }
 }

--- a/snark-verifier/src/pcs/kzg/multiopen/gwc19.rs
+++ b/snark-verifier/src/pcs/kzg/multiopen/gwc19.rs
@@ -6,7 +6,7 @@ use crate::{
         PolynomialCommitmentScheme, Query,
     },
     util::{
-        arithmetic::{CurveAffine, MultiMillerLoop, PrimeField},
+        arithmetic::{CurveAffine, MultiMillerLoop, Rotation},
         msm::Msm,
         transcript::TranscriptRead,
         Itertools,
@@ -31,7 +31,7 @@ where
 
     fn read_proof<T>(
         _: &Self::VerifyingKey,
-        queries: &[Query<M::Scalar>],
+        queries: &[Query<Rotation>],
         transcript: &mut T,
     ) -> Result<Self::Proof, Error>
     where
@@ -44,22 +44,23 @@ where
         svk: &Self::VerifyingKey,
         commitments: &[Msm<M::G1Affine, L>],
         z: &L::LoadedScalar,
-        queries: &[Query<M::Scalar, L::LoadedScalar>],
+        queries: &[Query<Rotation, L::LoadedScalar>],
         proof: &Self::Proof,
     ) -> Result<Self::Output, Error> {
         let sets = query_sets(queries);
         let powers_of_u = &proof.u.powers(sets.len());
         let f = {
-            let powers_of_v = proof
-                .v
-                .powers(sets.iter().map(|set| set.polys.len()).max().unwrap());
+            let powers_of_v = proof.v.powers(sets.iter().map(|set| set.polys.len()).max().unwrap());
             sets.iter()
                 .map(|set| set.msm(commitments, &powers_of_v))
                 .zip(powers_of_u.iter())
                 .map(|(msm, power_of_u)| msm * power_of_u)
                 .sum::<Msm<_, _>>()
         };
-        let z_omegas = sets.iter().map(|set| z.loader().load_const(&set.shift) * z);
+        let z_omegas = sets.iter().map(|set| {
+            let loaded_shift = set.loaded_shift.clone();
+            loaded_shift * z
+        });
 
         let rhs = proof
             .ws
@@ -67,11 +68,7 @@ where
             .zip(powers_of_u.iter())
             .map(|(w, power_of_u)| Msm::base(w) * power_of_u)
             .collect_vec();
-        let lhs = f + rhs
-            .iter()
-            .zip(z_omegas)
-            .map(|(uw, z_omega)| uw.clone() * &z_omega)
-            .sum();
+        let lhs = f + rhs.iter().zip(z_omegas).map(|(uw, z_omega)| uw.clone() * &z_omega).sum();
 
         Ok(KzgAccumulator::new(
             lhs.evaluate(Some(svk.g)),
@@ -97,7 +94,7 @@ where
     C: CurveAffine,
     L: Loader<C>,
 {
-    fn read<T>(queries: &[Query<C::Scalar>], transcript: &mut T) -> Result<Self, Error>
+    fn read<T>(queries: &[Query<Rotation>], transcript: &mut T) -> Result<Self, Error>
     where
         T: TranscriptRead<C, L>,
     {
@@ -108,22 +105,25 @@ where
     }
 }
 
-struct QuerySet<'a, F, T> {
-    shift: F,
+struct QuerySet<'a, S, T> {
+    shift: S,
+    loaded_shift: T,
     polys: Vec<usize>,
     evals: Vec<&'a T>,
 }
 
-impl<'a, F, T> QuerySet<'a, F, T>
+impl<'a, S, T> QuerySet<'a, S, T>
 where
-    F: PrimeField,
     T: Clone,
 {
     fn msm<C: CurveAffine, L: Loader<C, LoadedScalar = T>>(
         &self,
         commitments: &[Msm<'a, C, L>],
         powers_of_v: &[L::LoadedScalar],
-    ) -> Msm<C, L> {
+    ) -> Msm<C, L>
+    where
+        T: LoadedScalar<C::Scalar>,
+    {
         self.polys
             .iter()
             .zip(self.evals.iter().cloned())
@@ -137,9 +137,9 @@ where
     }
 }
 
-fn query_sets<F, T>(queries: &[Query<F, T>]) -> Vec<QuerySet<F, T>>
+fn query_sets<S, T>(queries: &[Query<S, T>]) -> Vec<QuerySet<S, T>>
 where
-    F: PrimeField,
+    S: PartialEq + Copy,
     T: Clone + PartialEq,
 {
     queries.iter().fold(Vec::new(), |mut sets, query| {
@@ -149,6 +149,7 @@ where
         } else {
             sets.push(QuerySet {
                 shift: query.shift,
+                loaded_shift: query.loaded_shift.clone(),
                 polys: vec![query.poly],
                 evals: vec![&query.eval],
             });
@@ -161,14 +162,10 @@ impl<M> CostEstimation<M::G1Affine> for KzgAs<M, Gwc19>
 where
     M: MultiMillerLoop,
 {
-    type Input = Vec<Query<M::Scalar>>;
+    type Input = Vec<Query<Rotation>>;
 
-    fn estimate_cost(queries: &Vec<Query<M::Scalar>>) -> Cost {
+    fn estimate_cost(queries: &Vec<Query<Rotation>>) -> Cost {
         let num_w = query_sets(queries).len();
-        Cost {
-            num_commitment: num_w,
-            num_msm: num_w,
-            ..Default::default()
-        }
+        Cost { num_commitment: num_w, num_msm: num_w, ..Default::default() }
     }
 }

--- a/snark-verifier/src/system/halo2.rs
+++ b/snark-verifier/src/system/halo2.rs
@@ -141,6 +141,7 @@ pub fn compile<'a, C: CurveAffine, P: Params<'a, C>>(
 
     PlonkProtocol {
         domain,
+        n_as_witness: None,
         preprocessed,
         num_instance: polynomials.num_instance(),
         num_witness: polynomials.num_witness(),

--- a/snark-verifier/src/system/halo2.rs
+++ b/snark-verifier/src/system/halo2.rs
@@ -141,7 +141,7 @@ pub fn compile<'a, C: CurveAffine, P: Params<'a, C>>(
 
     PlonkProtocol {
         domain,
-        n_as_witness: None,
+        domain_as_witness: None,
         preprocessed,
         num_instance: polynomials.num_instance(),
         num_witness: polynomials.num_witness(),

--- a/snark-verifier/src/verifier/plonk.rs
+++ b/snark-verifier/src/verifier/plonk.rs
@@ -62,8 +62,12 @@ where
         proof: &Self::Proof,
     ) -> Result<Self::Output, Error> {
         let common_poly_eval = {
-            let mut common_poly_eval =
-                CommonPolynomialEvaluation::new(&protocol.domain, protocol.langranges(), &proof.z);
+            let mut common_poly_eval = CommonPolynomialEvaluation::new(
+                &protocol.domain,
+                protocol.langranges(),
+                &proof.z,
+                &protocol.n_as_witness,
+            );
 
             L::batch_invert(common_poly_eval.denoms());
             common_poly_eval.evaluate();

--- a/snark-verifier/src/verifier/plonk.rs
+++ b/snark-verifier/src/verifier/plonk.rs
@@ -15,7 +15,10 @@ use crate::{
         AccumulationDecider, AccumulationScheme, AccumulatorEncoding, PolynomialCommitmentScheme,
         Query,
     },
-    util::{arithmetic::CurveAffine, transcript::TranscriptRead},
+    util::{
+        arithmetic::{CurveAffine, Rotation},
+        transcript::TranscriptRead,
+    },
     verifier::{plonk::protocol::CommonPolynomialEvaluation, SnarkVerifier},
     Error,
 };
@@ -66,7 +69,7 @@ where
                 &protocol.domain,
                 protocol.langranges(),
                 &proof.z,
-                &protocol.n_as_witness,
+                &protocol.domain_as_witness,
             );
 
             L::batch_invert(common_poly_eval.denoms());
@@ -144,7 +147,7 @@ where
     L: Loader<C>,
     AS: AccumulationScheme<C, L>
         + PolynomialCommitmentScheme<C, L, Output = AS::Accumulator>
-        + CostEstimation<C, Input = Vec<Query<C::Scalar>>>,
+        + CostEstimation<C, Input = Vec<Query<Rotation>>>,
 {
     type Input = PlonkProtocol<C, L>;
 
@@ -172,7 +175,7 @@ where
     L: Loader<C>,
     AS: AccumulationScheme<C, L>
         + PolynomialCommitmentScheme<C, L, Output = AS::Accumulator>
-        + CostEstimation<C, Input = Vec<Query<C::Scalar>>>,
+        + CostEstimation<C, Input = Vec<Query<Rotation>>>,
 {
     type Input = PlonkProtocol<C, L>;
 

--- a/snark-verifier/src/verifier/plonk/proof.rs
+++ b/snark-verifier/src/verifier/plonk/proof.rs
@@ -13,7 +13,10 @@ use crate::{
     },
     Error,
 };
-use std::{collections::HashMap, iter};
+use std::{
+    collections::{BTreeMap, HashMap},
+    iter,
+};
 
 /// Proof of PLONK with [`PolynomialCommitmentScheme`] that has
 /// [`AccumulationScheme`].
@@ -153,26 +156,42 @@ where
     }
 
     /// Empty queries
-    pub fn empty_queries(protocol: &PlonkProtocol<C, L>) -> Vec<pcs::Query<C::Scalar>> {
-        protocol
-            .queries
-            .iter()
-            .map(|query| {
-                let shift = protocol.domain.rotate_scalar(C::Scalar::one(), query.rotation);
-                pcs::Query::new(query.poly, shift)
-            })
-            .collect()
+    pub fn empty_queries(protocol: &PlonkProtocol<C, L>) -> Vec<pcs::Query<Rotation>> {
+        // `preprocessed` should always be non-empty, unless the circuit has no constraints or constants
+        protocol.queries.iter().map(|query| pcs::Query::new(query.poly, query.rotation)).collect()
     }
 
     pub(super) fn queries(
         &self,
         protocol: &PlonkProtocol<C, L>,
         mut evaluations: HashMap<Query, L::LoadedScalar>,
-    ) -> Vec<pcs::Query<C::Scalar, L::LoadedScalar>> {
+    ) -> Vec<pcs::Query<Rotation, L::LoadedScalar>> {
+        if protocol.queries.is_empty() {
+            return vec![];
+        }
+        let loader = evaluations[&protocol.queries[0]].loader();
+        let rotations =
+            protocol.queries.iter().map(|query| query.rotation).sorted().dedup().collect_vec();
+        let loaded_shifts = if let Some(domain) = protocol.domain_as_witness.as_ref() {
+            // the `rotation`s are still constants, it is only generator `omega` that might be witness
+            BTreeMap::from_iter(
+                rotations.into_iter().map(|rotation| (rotation, domain.rotate_one(rotation))),
+            )
+        } else {
+            BTreeMap::from_iter(rotations.into_iter().map(|rotation| {
+                (
+                    rotation,
+                    loader.load_const(&protocol.domain.rotate_scalar(C::Scalar::one(), rotation)),
+                )
+            }))
+        };
         Self::empty_queries(protocol)
             .into_iter()
             .zip(protocol.queries.iter().map(|query| evaluations.remove(query).unwrap()))
-            .map(|(query, eval)| query.with_evaluation(eval))
+            .map(|(query, eval)| {
+                let shift = loaded_shifts[&query.shift].clone();
+                query.with_evaluation(shift, eval)
+            })
             .collect()
     }
 

--- a/snark-verifier/src/verifier/plonk/protocol.rs
+++ b/snark-verifier/src/verifier/plonk/protocol.rs
@@ -9,12 +9,43 @@ use num_integer::Integer;
 use num_traits::One;
 use serde::{Deserialize, Serialize};
 use std::{
-    cmp::max,
+    cmp::{max, Ordering},
     collections::{BTreeMap, BTreeSet},
     fmt::Debug,
     iter::{self, Sum},
     ops::{Add, Mul, Neg, Sub},
 };
+
+/// Domain parameters to be optionally loaded as witnesses
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DomainAsWitness<C, L>
+where
+    C: CurveAffine,
+    L: Loader<C>,
+{
+    /// Number of rows in the domain
+    pub n: L::LoadedScalar,
+    /// Generator of the domain
+    pub gen: L::LoadedScalar,
+    /// Inverse generator of the domain
+    pub gen_inv: L::LoadedScalar,
+}
+
+impl<C, L> DomainAsWitness<C, L>
+where
+    C: CurveAffine,
+    L: Loader<C>,
+{
+    /// Rotate `F::one()` to given `rotation`.
+    pub fn rotate_one(&self, rotation: Rotation) -> L::LoadedScalar {
+        let loader = self.gen.loader();
+        match rotation.0.cmp(&0) {
+            Ordering::Equal => loader.load_one(),
+            Ordering::Greater => self.gen.pow_const(rotation.0 as u64),
+            Ordering::Less => self.gen_inv.pow_const(-rotation.0 as u64),
+        }
+    }
+}
 
 /// Protocol specifying configuration of a PLONK.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -34,8 +65,8 @@ where
         serialize = "L::LoadedScalar: Serialize",
         deserialize = "L::LoadedScalar: Deserialize<'de>"
     ))]
-    /// Optional: load `domain.n` as a witness
-    pub n_as_witness: Option<L::LoadedScalar>,
+    /// Optional: load `domain.n` and `domain.gen` as a witness
+    pub domain_as_witness: Option<DomainAsWitness<C, L>>,
 
     #[serde(bound(
         serialize = "L::LoadedEcPoint: Serialize",
@@ -123,7 +154,7 @@ where
             .map(|transcript_initial_state| loader.load_const(transcript_initial_state));
         PlonkProtocol {
             domain: self.domain.clone(),
-            n_as_witness: None,
+            domain_as_witness: None,
             preprocessed,
             num_instance: self.num_instance.clone(),
             num_witness: self.num_witness.clone(),
@@ -142,11 +173,16 @@ where
 #[cfg(feature = "loader_halo2")]
 mod halo2 {
     use crate::{
-        loader::halo2::{EccInstructions, Halo2Loader},
+        loader::{
+            halo2::{EccInstructions, Halo2Loader},
+            LoadedScalar,
+        },
         util::arithmetic::CurveAffine,
         verifier::plonk::PlonkProtocol,
     };
     use std::rc::Rc;
+
+    use super::DomainAsWitness;
 
     impl<C> PlonkProtocol<C>
     where
@@ -160,8 +196,13 @@ mod halo2 {
             loader: &Rc<Halo2Loader<C, EccChip>>,
             load_n_as_witness: bool,
         ) -> PlonkProtocol<C, Rc<Halo2Loader<C, EccChip>>> {
-            let n_as_witness = load_n_as_witness
-                .then(|| loader.assign_scalar(C::Scalar::from(self.domain.n as u64)));
+            let domain_as_witness = load_n_as_witness.then(|| {
+                let n = loader.assign_scalar(C::Scalar::from(self.domain.n as u64));
+                let gen = loader.assign_scalar(self.domain.gen);
+                let gen_inv = gen.invert().expect("subgroup generation is invertible");
+                DomainAsWitness { n, gen, gen_inv }
+            });
+
             let preprocessed = self
                 .preprocessed
                 .iter()
@@ -173,7 +214,7 @@ mod halo2 {
                 .map(|transcript_initial_state| loader.assign_scalar(*transcript_initial_state));
             PlonkProtocol {
                 domain: self.domain.clone(),
-                n_as_witness,
+                domain_as_witness,
                 preprocessed,
                 num_instance: self.num_instance.clone(),
                 num_witness: self.num_witness.clone(),
@@ -216,35 +257,37 @@ where
 {
     // if `n_as_witness` is Some, then we assume `n_as_witness` has value equal to `domain.n` (i.e., number of rows in the circuit)
     // and is loaded as a witness instead of a constant.
+    // The generator of `domain` also depends on `n`.
     pub fn new(
         domain: &Domain<C::Scalar>,
-        langranges: impl IntoIterator<Item = i32>,
+        lagranges: impl IntoIterator<Item = i32>,
         z: &L::LoadedScalar,
-        n_as_witness: &Option<L::LoadedScalar>,
+        domain_as_witness: &Option<DomainAsWitness<C, L>>,
     ) -> Self {
         let loader = z.loader();
 
-        let zn = if let Some(n) = n_as_witness.as_ref() {
-            z.pow_var(n, C::Scalar::S as usize + 1)
-        } else {
-            z.pow_const(domain.n as u64)
-        };
-        let langranges = langranges.into_iter().sorted().dedup().collect_vec();
-
+        let lagranges = lagranges.into_iter().sorted().dedup().collect_vec();
         let one = loader.load_one();
+
+        let (zn, n_inv, omegas) = if let Some(domain) = domain_as_witness.as_ref() {
+            let zn = z.pow_var(&domain.n, C::Scalar::S as usize + 1);
+            let n_inv = domain.n.invert().expect("n is not zero");
+            let omegas = lagranges.iter().map(|&i| domain.rotate_one(Rotation(i))).collect_vec();
+            (zn, n_inv, omegas)
+        } else {
+            let zn = z.pow_const(domain.n as u64);
+            let n_inv = loader.load_const(&domain.n_inv);
+            let omegas = lagranges
+                .iter()
+                .map(|&i| loader.load_const(&domain.rotate_scalar(C::Scalar::one(), Rotation(i))))
+                .collect_vec();
+            (zn, n_inv, omegas)
+        };
+
         let zn_minus_one = zn.clone() - &one;
         let zn_minus_one_inv = Fraction::one_over(zn_minus_one.clone());
 
-        let n_inv = if let Some(n) = n_as_witness.as_ref() {
-            n.invert().expect("n is not zero")
-        } else {
-            loader.load_const(&domain.n_inv)
-        };
         let numer = zn_minus_one.clone() * &n_inv;
-        let omegas = langranges
-            .iter()
-            .map(|&i| loader.load_const(&domain.rotate_scalar(C::Scalar::one(), Rotation(i))))
-            .collect_vec();
         let lagrange_evals = omegas
             .iter()
             .map(|omega| Fraction::new(numer.clone() * omega, z.clone() - omega))
@@ -255,7 +298,7 @@ where
             zn_minus_one,
             zn_minus_one_inv,
             identity: z.clone(),
-            lagrange: langranges.into_iter().zip(lagrange_evals).collect(),
+            lagrange: lagranges.into_iter().zip(lagrange_evals).collect(),
         }
     }
 


### PR DESCRIPTION
Universal aggregation circuit

It is universal in the sense that the `Circuit::Config` must stay the same (custom gates, # of columns), but we allow the fixed columns (especially selectors), to be loaded as witnesses into the aggregation circuit. 

Moreover, we can allow the number of rows `n = 2^k` in the circuit to also be loaded as a witness. 
- This required a slightly more extensive change because the verification algorithm depends on the generator `omega` of the order `n` subgroup of `F*`.