### PR TITLE
[feat(sdk)] `aggregate_snarks` returns loaded proof witnesses

### DIFF
--- a/snark-verifier-sdk/Cargo.toml
+++ b/snark-verifier-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snark-verifier-sdk"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 
 [dependencies]
@@ -22,14 +22,10 @@ snark-verifier = { path = "../snark-verifier", default-features = false }
 getset = "0.1.2"
 
 # loader_evm
-ethereum-types = { version = "0.14.1", default-features = false, features = [
-    "std",
-], optional = true }
+ethereum-types = { version = "0.14.1", default-features = false, features = ["std"], optional = true }
 
 # zkevm benchmarks
-zkevm-circuits = { git = "https://github.com/privacy-scaling-explorations/zkevm-circuits.git", rev = "f834e61", features = [
-    "test",
-], optional = true }
+zkevm-circuits = { git = "https://github.com/privacy-scaling-explorations/zkevm-circuits.git", rev = "f834e61", features = ["test"], optional = true }
 bus-mapping = { git = "https://github.com/privacy-scaling-explorations/zkevm-circuits.git", rev = "f834e61", optional = true }
 eth-types = { git = "https://github.com/privacy-scaling-explorations/zkevm-circuits.git", rev = "f834e61", optional = true }
 mock = { git = "https://github.com/privacy-scaling-explorations/zkevm-circuits.git", rev = "f834e61", optional = true }
@@ -45,13 +41,7 @@ crossterm = { version = "0.25" }
 tui = { version = "0.19", default-features = false, features = ["crossterm"] }
 
 [features]
-default = [
-    "loader_halo2",
-    "loader_evm",
-    "halo2-axiom",
-    "halo2-base/jemallocator",
-    "display",
-]
+default = ["loader_halo2", "loader_evm", "halo2-axiom", "halo2-base/jemallocator", "display"]
 display = ["snark-verifier/display", "dep:ark-std"]
 loader_evm = ["snark-verifier/loader_evm", "dep:ethereum-types"]
 loader_halo2 = ["snark-verifier/loader_halo2"]

--- a/snark-verifier/Cargo.toml
+++ b/snark-verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snark-verifier"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Previously `aggregate_snarks` took in a proof as bytes, and internally assigned the bytes to witnesses and used the witnesses in the transcript as part of the proof verification process. However we did not expose the assigned proof witnesses. This PR exposes the assigned proof witnesses by adding them to `SnarkAggregationOutput`.

The `PlonkProof` struct already stores all the proof witnesses, but they are stored in pieces as they are needed in the proof verification. In particular the `pcs` subfield depends on the multi-open commitment scheme used (SHPLONK or GWC). It seemed more error-prone to try to extract the proof witnesses from `PlonkProof` in this way, so instead I add a `loaded_stream` field to the `PoseidonTranscript` struct, and just push a copy of whatever new witness is assigned when `read_scalar` or `read_ec_point` is called.