### PR TITLE
0.1.6-rc -> 0.1.7-rc

### DIFF
--- a/snark-verifier-sdk/Cargo.toml
+++ b/snark-verifier-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snark-verifier-sdk"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 
 [dependencies]
@@ -22,14 +22,10 @@ snark-verifier = { path = "../snark-verifier", default-features = false }
 getset = "0.1.2"
 
 # loader_evm
-ethereum-types = { version = "0.14.1", default-features = false, features = [
-    "std",
-], optional = true }
+ethereum-types = { version = "0.14.1", default-features = false, features = ["std"], optional = true }
 
 # zkevm benchmarks
-zkevm-circuits = { git = "https://github.com/privacy-scaling-explorations/zkevm-circuits.git", rev = "f834e61", features = [
-    "test",
-], optional = true }
+zkevm-circuits = { git = "https://github.com/privacy-scaling-explorations/zkevm-circuits.git", rev = "f834e61", features = ["test"], optional = true }
 bus-mapping = { git = "https://github.com/privacy-scaling-explorations/zkevm-circuits.git", rev = "f834e61", optional = true }
 eth-types = { git = "https://github.com/privacy-scaling-explorations/zkevm-circuits.git", rev = "f834e61", optional = true }
 mock = { git = "https://github.com/privacy-scaling-explorations/zkevm-circuits.git", rev = "f834e61", optional = true }
@@ -45,13 +41,7 @@ crossterm = { version = "0.25" }
 tui = { version = "0.19", default-features = false, features = ["crossterm"] }
 
 [features]
-default = [
-    "loader_halo2",
-    "loader_evm",
-    "halo2-axiom",
-    "halo2-base/jemallocator",
-    "display",
-]
+default = ["loader_halo2", "loader_evm", "halo2-axiom", "halo2-base/jemallocator", "display"]
 display = ["snark-verifier/display", "dep:ark-std"]
 loader_evm = ["snark-verifier/loader_evm", "dep:ethereum-types"]
 loader_halo2 = ["snark-verifier/loader_halo2"]

--- a/snark-verifier-sdk/src/halo2/aggregation.rs
+++ b/snark-verifier-sdk/src/halo2/aggregation.rs
@@ -26,13 +26,14 @@ use snark_verifier::util::arithmetic::fe_to_limbs;
 use snark_verifier::{
     loader::{
         self,
-        halo2::halo2_ecc::{self, bn254::FpChip},
+        halo2::halo2_ecc::{self, bigint::ProperCrtUint, bn254::FpChip},
         native::NativeLoader,
     },
     pcs::{
         kzg::{KzgAccumulator, KzgAsProvingKey, KzgAsVerifyingKey, KzgSuccinctVerifyingKey},
         AccumulationScheme, AccumulationSchemeProver, PolynomialCommitmentScheme,
     },
+    system::halo2::transcript::halo2::TranscriptObject,
     verifier::SnarkVerifier,
 };
 use std::{fs::File, mem, path::Path, rc::Rc};
@@ -57,6 +58,8 @@ pub struct SnarkAggregationWitness<'a> {
     /// This returns the assigned `preprocessed` and `transcript_initial_state` values as a vector of assigned values, one for each aggregated snark.
     /// These can then be exposed as public instances.
     pub preprocessed: Vec<PreprocessedAndDomainAsWitness>,
+    /// The proof transcript, as loaded scalars and elliptic curve points, for each SNARK that was aggregated.
+    pub proof_transcripts: Vec<Vec<TranscriptObject<G1Affine, Rc<Halo2Loader<'a>>>>>,
 }
 
 /// Different possible stages of universality the aggregation circuit can support
@@ -133,9 +136,9 @@ where
     );
 
     let preprocessed_as_witness = universality.preprocessed_as_witness();
-    let mut accumulators = snarks
+    let (proof_transcripts, accumulators): (Vec<_>, Vec<_>) = snarks
         .iter()
-        .flat_map(|snark: &Snark| {
+        .map(|snark: &Snark| {
             let protocol = if preprocessed_as_witness {
                 // always load `domain.n` as witness if vkey is witness
                 snark.protocol.loaded_preprocessed_as_witness(loader, universality.k_as_witness())
@@ -185,10 +188,21 @@ where
             previous_instances.push(
                 instances.into_iter().flatten().map(|scalar| scalar.into_assigned()).collect(),
             );
-
-            accumulator
+            let proof_transcript = transcript.loaded_stream.clone();
+            debug_assert_eq!(
+                snark.proof().len(),
+                proof_transcript
+                    .iter()
+                    .map(|t| match t {
+                        TranscriptObject::Scalar(_) => 32,
+                        TranscriptObject::EcPoint(_) => 32,
+                    })
+                    .sum::<usize>()
+            );
+            (proof_transcript, accumulator)
         })
-        .collect_vec();
+        .unzip();
+    let mut accumulators = accumulators.into_iter().flatten().collect_vec();
 
     let accumulator = if accumulators.len() > 1 {
         transcript.new_stream(as_proof);
@@ -208,6 +222,7 @@ where
         previous_instances,
         accumulator,
         preprocessed: preprocessed_witnesses,
+        proof_transcripts,
     }
 }
 
@@ -324,6 +339,15 @@ pub struct SnarkAggregationOutput {
     /// This returns the assigned `preprocessed` and `transcript_initial_state` values as a vector of assigned values, one for each aggregated snark.
     /// These can then be exposed as public instances.
     pub preprocessed: Vec<PreprocessedAndDomainAsWitness>,
+    /// The proof transcript, as loaded scalars and elliptic curve points, for each SNARK that was aggregated.
+    pub proof_transcripts: Vec<Vec<AssignedTranscriptObject>>,
+}
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone, Debug)]
+pub enum AssignedTranscriptObject {
+    Scalar(AssignedValue<Fr>),
+    EcPoint(halo2_ecc::ecc::EcPoint<Fr, ProperCrtUint<Fr>>),
 }
 
 /// Given snarks, this populates the circuit builder with the virtual cells and constraints necessary to verify all the snarks.
@@ -397,8 +421,12 @@ where
     let loader = Halo2Loader::new(ecc_chip, tmp_pool);
 
     // run witness and copy constraint generation
-    let SnarkAggregationWitness { previous_instances, accumulator, preprocessed } =
-        aggregate::<AS>(&svk, &loader, &snarks, as_proof.as_slice(), universality);
+    let SnarkAggregationWitness {
+        previous_instances,
+        accumulator,
+        preprocessed,
+        proof_transcripts,
+    } = aggregate::<AS>(&svk, &loader, &snarks, as_proof.as_slice(), universality);
     let lhs = accumulator.lhs.assigned();
     let rhs = accumulator.rhs.assigned();
     let accumulator = lhs
@@ -410,6 +438,22 @@ where
         .chain(rhs.y().limbs().iter())
         .copied()
         .collect_vec();
+    let proof_transcripts = proof_transcripts
+        .into_iter()
+        .map(|transcript| {
+            transcript
+                .into_iter()
+                .map(|obj| match obj {
+                    TranscriptObject::Scalar(scalar) => {
+                        AssignedTranscriptObject::Scalar(scalar.into_assigned())
+                    }
+                    TranscriptObject::EcPoint(point) => {
+                        AssignedTranscriptObject::EcPoint(point.into_assigned())
+                    }
+                })
+                .collect()
+        })
+        .collect();
 
     #[cfg(debug_assertions)]
     {
@@ -422,7 +466,7 @@ where
     }
     // put back `pool` into `builder`
     *pool = loader.take_ctx();
-    SnarkAggregationOutput { previous_instances, accumulator, preprocessed }
+    SnarkAggregationOutput { previous_instances, accumulator, preprocessed, proof_transcripts }
 }
 
 impl AggregationCircuit {
@@ -452,7 +496,7 @@ impl AggregationCircuit {
         let svk: Svk = params.get_g()[0].into();
         let mut builder = BaseCircuitBuilder::from_stage(stage).use_params(config_params.into());
         let range = builder.range_chip();
-        let SnarkAggregationOutput { previous_instances, accumulator, preprocessed } =
+        let SnarkAggregationOutput { previous_instances, accumulator, preprocessed, .. } =
             aggregate_snarks::<AS>(builder.pool(0), &range, svk, snarks, universality);
         assert_eq!(
             builder.assigned_instances.len(),

--- a/snark-verifier/Cargo.toml
+++ b/snark-verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snark-verifier"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 
 [dependencies]

--- a/snark-verifier/src/loader/evm/code.rs
+++ b/snark-verifier/src/loader/evm/code.rs
@@ -21,7 +21,7 @@ impl SolidityAssemblyCode {
             "
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.21;
 
 contract Halo2Verifier {{
     fallback(bytes calldata) external returns (bytes memory) {{

--- a/snark-verifier/src/system/halo2.rs
+++ b/snark-verifier/src/system/halo2.rs
@@ -716,7 +716,9 @@ impl<C: CurveAffine> Transcript<C, MockChallenge> for MockTranscript<C::Scalar> 
     }
 }
 
-fn transcript_initial_state<C: CurveAffine>(vk: &VerifyingKey<C>) -> C::Scalar {
+/// Returns the transcript initial state of the [VerifyingKey].
+/// Roundabout way to do it because [VerifyingKey] doesn't expose the field.
+pub fn transcript_initial_state<C: CurveAffine>(vk: &VerifyingKey<C>) -> C::Scalar {
     let mut transcript = MockTranscript::default();
     vk.hash_into(&mut transcript).unwrap();
     transcript.0


### PR DESCRIPTION
Includes PRs:
- https://github.com/axiom-crypto/snark-verifier/pull/34 Purely a refactor to allow snark aggregation in an existing `BaseCircuitBuilder` for dev convenience
- https://github.com/axiom-crypto/snark-verifier/pull/36 No security-related changes, but modifies `PoseidonTranscript` so that when using `Halo2Loader`, it tracks the private witnesses as they are assigned in the read stream.