### PR TITLE
chore: `snark-verifier` re-exports `halo2-base`, `halo2-ecc`

### DIFF
--- a/snark-verifier-sdk/src/lib.rs
+++ b/snark-verifier-sdk/src/lib.rs
@@ -25,6 +25,8 @@ use std::{
     path::Path,
 };
 
+pub use snark_verifier;
+
 #[cfg(feature = "loader_evm")]
 pub mod evm;
 #[cfg(feature = "loader_halo2")]

--- a/snark-verifier/src/lib.rs
+++ b/snark-verifier/src/lib.rs
@@ -13,6 +13,10 @@ pub mod verifier;
 pub(crate) use halo2_base::halo2_proofs;
 pub(crate) use halo2_proofs::halo2curves as halo2_curves;
 
+pub use halo2_base;
+#[cfg(feature = "loader_halo2")]
+pub use halo2_ecc;
+
 /// Error that could happen while verification.
 #[derive(Clone, Debug)]
 pub enum Error {


### PR DESCRIPTION
and `snark-verifier-sdk` re-exports `snark-verifier`. This is to minimize cargo dependency / version issues until we publish to crates.io.