### PR TITLE
[feat] update `gen_dummy_snark` to help with keygen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,20 +1135,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "halo2-axiom"
+version = "0.4.1"
+dependencies = [
+ "blake2b_simd",
+ "crossbeam",
+ "ff",
+ "group",
+ "halo2curves-axiom",
+ "itertools 0.11.0",
+ "maybe-rayon",
+ "pairing",
+ "rand",
+ "rand_core",
+ "rustc-hash",
+ "sha3 0.10.8",
+ "tracing",
+]
+
+[[package]]
 name = "halo2-base"
 version = "0.4.0"
-source = "git+https://github.com/axiom-crypto/halo2-lib.git?branch=release-0.4.1-rc#a30e3b18d285c8b0d7145c1c34297edd9433df60"
 dependencies = [
  "getset",
- "halo2_proofs 0.2.0",
- "halo2_proofs 0.2.0 (git+https://github.com/privacy-scaling-explorations/halo2.git?rev=7a21656)",
+ "halo2-axiom",
+ "halo2_proofs",
  "itertools 0.11.0",
  "jemallocator",
  "log",
  "num-bigint",
  "num-integer",
  "num-traits",
- "poseidon-rs",
+ "poseidon-primitives",
  "rand_chacha",
  "rayon",
  "rustc-hash",
@@ -1159,7 +1177,6 @@ dependencies = [
 [[package]]
 name = "halo2-ecc"
 version = "0.4.0"
-source = "git+https://github.com/axiom-crypto/halo2-lib.git?branch=release-0.4.1-rc#a30e3b18d285c8b0d7145c1c34297edd9433df60"
 dependencies = [
  "halo2-base",
  "itertools 0.10.5",
@@ -1178,30 +1195,12 @@ dependencies = [
 [[package]]
 name = "halo2_proofs"
 version = "0.2.0"
-dependencies = [
- "blake2b_simd",
- "crossbeam",
- "ff",
- "group",
- "halo2curves 0.4.0",
- "maybe-rayon",
- "pairing",
- "rand",
- "rand_core",
- "rustc-hash",
- "sha3 0.10.8",
- "tracing",
-]
-
-[[package]]
-name = "halo2_proofs"
-version = "0.2.0"
 source = "git+https://github.com/privacy-scaling-explorations/halo2.git?rev=7a21656#7a2165617195d8baa422ca7b2b364cef02380390"
 dependencies = [
  "blake2b_simd",
  "ff",
  "group",
- "halo2curves 0.1.0",
+ "halo2curves",
  "maybe-rayon",
  "rand_chacha",
  "rand_core",
@@ -1230,9 +1229,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "halo2curves"
-version = "0.4.0"
-source = "git+https://github.com/axiom-crypto/halo2curves.git?branch=main#e185711b6ba8f3e22f2af8bf24a5fc84b781ca46"
+name = "halo2curves-axiom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d47eaec6a3040c2fbaa020716bf571b0c55025126242510f774183aff84b92e"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -1910,9 +1910,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "poseidon-rs"
+name = "poseidon-primitives"
 version = "0.1.1"
-source = "git+https://github.com/axiom-crypto/poseidon-circuit.git?rev=1aee4a1#1aee4a1bf6220578924079aac4f2eee3874116a1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd95570f7ea849b4187298b5bb229643e44e1d47ddf3979d0db8a1c28be26a8"
 dependencies = [
  "bitvec",
  "ff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "halo2-base"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "getset",
  "halo2-axiom",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "halo2-ecc"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "halo2-base",
  "itertools 0.10.5",

--- a/snark-verifier-sdk/examples/standard_plonk.rs
+++ b/snark-verifier-sdk/examples/standard_plonk.rs
@@ -182,6 +182,7 @@ fn main() {
     let lookup_bits = k as usize - 1;
     let params = gen_srs(k);
     let snarks = [(); 1].map(|_| gen_application_snark(&params_app));
+    dbg!(&snarks[0].protocol);
 
     let mut agg_circuit = AggregationCircuit::new::<SHPLONK>(
         CircuitBuilderStage::Keygen,

--- a/snark-verifier-sdk/examples/standard_plonk.rs
+++ b/snark-verifier-sdk/examples/standard_plonk.rs
@@ -182,7 +182,6 @@ fn main() {
     let lookup_bits = k as usize - 1;
     let params = gen_srs(k);
     let snarks = [(); 1].map(|_| gen_application_snark(&params_app));
-    dbg!(&snarks[0].protocol);
 
     let mut agg_circuit = AggregationCircuit::new::<SHPLONK>(
         CircuitBuilderStage::Keygen,

--- a/snark-verifier-sdk/src/halo2.rs
+++ b/snark-verifier-sdk/src/halo2.rs
@@ -46,6 +46,7 @@ use std::{
 };
 
 pub mod aggregation;
+pub mod utils;
 
 // Poseidon parameters
 // We use the same ones Scroll uses for security: https://github.com/scroll-tech/poseidon-circuit/blob/714f50c7572a4ff6f2b1fa51a9604a99cd7b6c71/src/poseidon/primitives/bn256/fp.rs

--- a/snark-verifier-sdk/src/halo2.rs
+++ b/snark-verifier-sdk/src/halo2.rs
@@ -388,11 +388,9 @@ where
     let protocol = compile(
         params,
         vk,
-        Config::kzg()
-            .with_num_instance(num_instance.clone())
-            .with_accumulator_indices(accumulator_indices),
+        Config::kzg().with_num_instance(num_instance).with_accumulator_indices(accumulator_indices),
     );
-    gen_dummy_snark_from_protocol::<AS>(protocol, num_instance)
+    gen_dummy_snark_from_protocol::<AS>(protocol)
 }
 
 /// Creates a dummy snark in the correct shape corresponding to the given Plonk protocol.
@@ -401,14 +399,11 @@ where
 /// with this protocol.
 ///
 /// Note that this function does not need to know the concrete `Circuit` type.
-pub fn gen_dummy_snark_from_protocol<AS>(
-    protocol: PlonkProtocol<G1Affine>,
-    num_instance: Vec<usize>,
-) -> Snark
+pub fn gen_dummy_snark_from_protocol<AS>(protocol: PlonkProtocol<G1Affine>) -> Snark
 where
     AS: NativeKzgAccumulationScheme,
 {
-    let instances = num_instance.into_iter().map(|n| vec![Fr::default(); n]).collect();
+    let instances = protocol.num_instance.iter().map(|&n| vec![Fr::default(); n]).collect();
     let proof = {
         let mut transcript = PoseidonTranscript::<NativeLoader, _>::new::<SECURE_MDS>(Vec::new());
         for _ in 0..protocol

--- a/snark-verifier-sdk/src/halo2/aggregation.rs
+++ b/snark-verifier-sdk/src/halo2/aggregation.rs
@@ -53,6 +53,10 @@ pub struct PreprocessedAndDomainAsWitness {
 
 #[derive(Clone, Debug)]
 pub struct SnarkAggregationWitness<'a> {
+    /// The (flattened) public instances from previous snarks that were aggregated, now collected as PRIVATE assigned values.
+    /// * If previous snark was from aggregation circuit, the previous instances will still contain the old KZG accumulator.
+    ///
+    /// The user can optionally append these private witnesses to `inner.assigned_instances` to expose them.
     pub previous_instances: Vec<Vec<AssignedValue<Fr>>>,
     pub accumulator: KzgAccumulator<G1Affine, Rc<Halo2Loader<'a>>>,
     /// This returns the assigned `preprocessed` and `transcript_initial_state` values as a vector of assigned values, one for each aggregated snark.
@@ -295,8 +299,10 @@ impl TryFrom<BaseCircuitParams> for AggregationConfigParams {
 pub struct AggregationCircuit {
     /// Circuit builder consisting of virtual region managers
     pub builder: BaseCircuitBuilder<Fr>,
-    // the public instances from previous snarks that were aggregated, now collected as PRIVATE assigned values
-    // the user can optionally append these to `inner.assigned_instances` to expose them
+    /// The (flattened) public instances from previous snarks that were aggregated, now collected as PRIVATE assigned values.
+    /// * If previous snark was from aggregation circuit, the previous instances will still contain the old KZG accumulator.
+    ///
+    /// The user can optionally append these private witnesses to `inner.assigned_instances` to expose them.
     #[getset(get = "pub")]
     previous_instances: Vec<Vec<AssignedValue<Fr>>>,
     /// This returns the assigned `preprocessed_digest` (vkey), optional `transcript_initial_state`, `domain.n` (optional), and `omega` (optional) values as a vector of assigned values, one for each aggregated snark.

--- a/snark-verifier-sdk/src/halo2/utils.rs
+++ b/snark-verifier-sdk/src/halo2/utils.rs
@@ -79,3 +79,13 @@ pub trait KeygenAggregationCircuitIntent {
         self.build_keygen_circuit_from_snarks(snarks)
     }
 }
+
+impl<'a> From<&'a AggregationDependencyIntentOwned> for AggregationDependencyIntent<'a> {
+    fn from(intent: &'a AggregationDependencyIntentOwned) -> Self {
+        Self {
+            vk: &intent.vk,
+            num_instance: &intent.num_instance,
+            is_aggregation: intent.is_aggregation,
+        }
+    }
+}

--- a/snark-verifier-sdk/src/halo2/utils.rs
+++ b/snark-verifier-sdk/src/halo2/utils.rs
@@ -1,0 +1,77 @@
+use std::path::Path;
+
+use halo2_base::{
+    halo2_proofs::{
+        arithmetic::Field,
+        halo2curves::bn256::{Fr, G1Affine},
+        plonk::{Circuit, VerifyingKey},
+    },
+    utils::fs::read_params,
+};
+
+use crate::{CircuitExt, Snark, SHPLONK};
+
+use super::{aggregation::AggregationCircuit, gen_dummy_snark_from_vk};
+
+#[derive(Clone, Copy, Debug)]
+pub struct AggregationDependencyIntent<'a> {
+    pub vk: &'a VerifyingKey<G1Affine>,
+    pub num_instance: &'a [usize],
+    pub is_aggregation: bool,
+}
+
+/// This trait should be implemented on the minimal circuit configuration data necessary to
+/// completely determine an aggregation circuit
+/// (independent of circuit inputs or specific snarks to be aggregated).
+/// This is used to generate a _dummy_ instantiation of a concrete `Circuit` type for the purposes of key generation.
+/// This dummy instantiation just needs to have the correct arithmetization format, but the witnesses do not need to
+/// satisfy constraints.
+///
+/// This trait is specialized for aggregation circuits, which need to aggregate **dependency** snarks.
+/// The aggregation circuit should only depend on the verifying key of each dependency snark.
+pub trait KeygenAggregationCircuitIntent {
+    /// Concrete circuit type. Defaults to [`AggregationCircuit`].
+    type AggregationCircuit: Circuit<Fr> = AggregationCircuit;
+
+    /// The **ordered** list of [`VerifyingKey`]s of the circuits to be aggregated.
+    fn vk_of_dependencies(&self) -> Vec<AggregationDependencyIntent>;
+
+    /// Builds a _dummy_ instantiation of `Self::AggregationCircuit` for the purposes of key generation.
+    /// Assumes that `snarks` is an ordered list of [`Snark`]s, where the `i`th snark corresponds to the `i`th [`VerifyingKey`] in `vk_of_dependencies`.
+    /// The `snarks` only need to have the correct witness sizes (e.g., proof length) but the
+    /// snarks do _not_ need to verify.
+    ///
+    /// May specify additional custom logic for building the aggregation circuit from the snarks.
+    fn build_keygen_circuit_from_snarks(self, snarks: Vec<Snark>) -> Self::AggregationCircuit;
+
+    /// Builds a _dummy_ instantiation of `Self::AggregationCircuit` for the purposes of key generation.
+    ///
+    /// Generates dummy snarks from the verifying keys in `vk_of_dependencies`, **assuming** that SHPLONK is
+    /// used for the multi-open scheme.
+    /// To do so, it will try to read KZG trusted setup files from the directory set by environmental variable
+    /// `PARAMS_DIR` or `./params/`.
+    // The `params` is not actually used, so this requirement should be removed in the future:
+    // requires refactoring `compile`.
+    fn build_keygen_circuit_shplonk(self) -> Self::AggregationCircuit
+    where
+        Self: Sized,
+    {
+        let snarks = self
+            .vk_of_dependencies()
+            .into_iter()
+            .map(|AggregationDependencyIntent { vk, num_instance, is_aggregation }| {
+                let k = vk.get_domain().k();
+                let params = read_params(k);
+                let accumulator_indices =
+                    is_aggregation.then_some(AggregationCircuit::accumulator_indices().unwrap());
+                gen_dummy_snark_from_vk::<SHPLONK>(
+                    &params,
+                    vk,
+                    num_instance.to_vec(),
+                    accumulator_indices,
+                )
+            })
+            .collect();
+        self.build_keygen_circuit_from_snarks(snarks)
+    }
+}

--- a/snark-verifier-sdk/src/halo2/utils.rs
+++ b/snark-verifier-sdk/src/halo2/utils.rs
@@ -31,7 +31,7 @@ pub trait KeygenAggregationCircuitIntent {
     type AggregationCircuit: Circuit<Fr> = AggregationCircuit;
 
     /// The **ordered** list of [`VerifyingKey`]s of the circuits to be aggregated.
-    fn vk_of_dependencies(&self) -> Vec<AggregationDependencyIntent>;
+    fn intent_of_dependencies(&self) -> Vec<AggregationDependencyIntent>;
 
     /// Builds a _dummy_ instantiation of `Self::AggregationCircuit` for the purposes of key generation.
     /// Assumes that `snarks` is an ordered list of [`Snark`]s, where the `i`th snark corresponds to the `i`th [`VerifyingKey`] in `vk_of_dependencies`.
@@ -54,7 +54,7 @@ pub trait KeygenAggregationCircuitIntent {
         Self: Sized,
     {
         let snarks = self
-            .vk_of_dependencies()
+            .intent_of_dependencies()
             .into_iter()
             .map(|AggregationDependencyIntent { vk, num_instance, is_aggregation }| {
                 let k = vk.get_domain().k();

--- a/snark-verifier-sdk/src/halo2/utils.rs
+++ b/snark-verifier-sdk/src/halo2/utils.rs
@@ -17,6 +17,13 @@ pub struct AggregationDependencyIntent<'a> {
     pub is_aggregation: bool,
 }
 
+#[derive(Clone, Debug)]
+pub struct AggregationDependencyIntentOwned {
+    pub vk: VerifyingKey<G1Affine>,
+    pub num_instance: Vec<usize>,
+    pub is_aggregation: bool,
+}
+
 /// This trait should be implemented on the minimal circuit configuration data necessary to
 /// completely determine an aggregation circuit
 /// (independent of circuit inputs or specific snarks to be aggregated).

--- a/snark-verifier-sdk/src/halo2/utils.rs
+++ b/snark-verifier-sdk/src/halo2/utils.rs
@@ -1,8 +1,5 @@
-use std::path::Path;
-
 use halo2_base::{
     halo2_proofs::{
-        arithmetic::Field,
         halo2curves::bn256::{Fr, G1Affine},
         plonk::{Circuit, VerifyingKey},
     },


### PR DESCRIPTION
No circuit logic was changed.

* `gen_dummy_snark` needs to account for `ConcreteCircuit::Params` with the new feature `"circuit-params"` in halo2.
* Add `gen_dummy_snark_from_vk` that gives a dummy snark with correct "shape" from vkey without knowledge of circuit type.
* Add `gen_dummy_snark_from_protocol` that does same thing as above from `PlonkProtocol`
* Add trait and helper tool for generating `AggregationCircuit`, for the purposes of keygen, from just verifying keys of dependencies.

The idea is this should be used to implement `KeygenCircuitIntent` from https://github.com/axiom-crypto/halo2-lib/pull/227 but I don't do it here since the exact `Pinning` type may vary.