### PR TITLE
fix compile error when `halo2-pse` feature active

### DIFF
--- a/snark-verifier/src/lib.rs
+++ b/snark-verifier/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![allow(clippy::type_complexity, clippy::too_many_arguments, clippy::upper_case_acronyms)]
 #![deny(missing_debug_implementations, missing_docs, unsafe_code, rustdoc::all)]
+#![feature(associated_type_defaults)]
 
 pub mod cost;
 pub mod loader;

--- a/snark-verifier/src/util/arithmetic.rs
+++ b/snark-verifier/src/util/arithmetic.rs
@@ -8,7 +8,7 @@ pub use halo2_curves::{
         prime::PrimeCurveAffine,
         Curve, Group, GroupEncoding,
     },
-    Coordinates, CurveAffine, CurveExt,
+    pairing, Coordinates, CurveAffine, CurveExt,
 };
 use num_bigint::BigUint;
 use num_traits::One;
@@ -22,7 +22,11 @@ use std::{
 };
 
 /// [pairing::MultiMillerLoop] with [`std::fmt::Debug`].
-pub trait MultiMillerLoop: pairing::MultiMillerLoop + Debug {}
+pub trait MultiMillerLoop: pairing::MultiMillerLoop + Debug {
+    #[cfg(feature = "halo2-pse")]
+    /// Scalar type - PSE/halo2 has `Scalar` while Axiom/halo2 has `Fr`.
+    type Fr: PrimeField = Self::Scalar;
+}
 
 impl<M: pairing::MultiMillerLoop + Debug> MultiMillerLoop for M {}
 


### PR DESCRIPTION
Note: Base branch of this PR is set to release to show the changes. But it is intended to be merged on another branch.

## how to reproduce issue?

Change default feature `halo2-axiom` to `halo2-pse` in both `snark-verifier` and `snark-verifier-sdk` 's Cargo.toml file. And `cargo build`.

It will give this error:

```
error[E0277]: the trait bound `Bn256: pairing::MultiMillerLoop` is not satisfied
   --> snark-verifier-sdk/src/evm.rs:119:54
    |
119 |     > + AccumulationDecider<G1Affine, Rc<EvmLoader>, DecidingKey = KzgDecidingKey<Bn256>>;
    |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `pairing::MultiMillerLoop` is not implemented for `Bn256`
    |
    = note: required for `Bn256` to implement `snark_verifier::util::arithmetic::MultiMillerLoop`
note: required by a bound in `KzgDecidingKey`
   --> /Users/sohamzemse/Workspace/axiom/static-call-work/snark-verifier/snark-verifier/src/pcs/kzg/decider.rs:15:30
    |
15  | pub struct KzgDecidingKey<M: MultiMillerLoop> {
    |                              ^^^^^^^^^^^^^^^ required by this bound in `KzgDecidingKey`
```

Applying the patch in this PR fixes this issue.