### PR TITLE
chore: enable derive serde for "halo2-pse"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,15 +486,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "41daef31d7a747c5c847246f36de49ced6f7403b4cdabc807a97b5cc184cda7a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -1204,6 +1204,7 @@ dependencies = [
  "blake2b_simd",
  "ff",
  "group",
+ "hex",
  "lazy_static",
  "num-bigint",
  "num-traits",
@@ -1213,6 +1214,8 @@ dependencies = [
  "rand",
  "rand_core",
  "rayon",
+ "serde",
+ "serde_arrays",
  "static_assertions",
  "subtle",
 ]
@@ -1995,9 +1998,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -2130,9 +2133,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2142,9 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "3b7fa1134405e2ec9353fd416b17f8dacd46c473d7d3fd1cf202706a14eb792a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2514,9 +2517,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
@@ -2560,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b187f0231d56fe41bfb12034819dd2bf336422a5866de41bc3fec4b2e3883e8"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "snark-verifier"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,6 +1124,8 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 [[package]]
 name = "halo2-axiom"
 version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d7b1243109adf85c716fa33dafb3c602694358821a0a1326a62f160d85600d"
 dependencies = [
  "blake2b_simd",
  "crossbeam",
@@ -1143,6 +1145,7 @@ dependencies = [
 [[package]]
 name = "halo2-base"
 version = "0.4.1"
+source = "git+https://github.com/axiom-crypto/halo2-lib.git?tag=v0.4.1-git#2fe813b3ccd4f224da195d61829effb20599dcbd"
 dependencies = [
  "getset",
  "halo2-axiom",
@@ -1164,6 +1167,7 @@ dependencies = [
 [[package]]
 name = "halo2-ecc"
 version = "0.4.1"
+source = "git+https://github.com/axiom-crypto/halo2-lib.git?tag=v0.4.1-git#2fe813b3ccd4f224da195d61829effb20599dcbd"
 dependencies = [
  "halo2-base",
  "itertools 0.11.0",

--- a/snark-verifier-sdk/src/halo2.rs
+++ b/snark-verifier-sdk/src/halo2.rs
@@ -198,7 +198,6 @@ where
         MSMAccumulator = DualMSM<'params, Bn256>,
     >,
 {
-    #[cfg(feature = "halo2-axiom")]
     if let Some(path) = &path {
         if let Ok(snark) = read_snark(path) {
             return snark;
@@ -213,21 +212,10 @@ where
     );
 
     let instances = circuit.instances();
-    #[cfg(feature = "halo2-axiom")]
     let proof = gen_proof::<ConcreteCircuit, P, V>(params, pk, circuit, instances.clone(), None);
     // If we can't serialize the entire snark, at least serialize the proof
-    #[cfg(not(feature = "halo2-axiom"))]
-    let proof = {
-        let path = path.map(|path| {
-            let path = path.as_ref().to_str().unwrap();
-            (format!("{path}.instances"), format!("{path}.proof"))
-        });
-        let paths = path.as_ref().map(|path| (Path::new(&path.0), Path::new(&path.1)));
-        gen_proof::<ConcreteCircuit, P, V>(params, pk, circuit, instances.clone(), paths)
-    };
 
     let snark = Snark::new(protocol, instances, proof);
-    #[cfg(feature = "halo2-axiom")]
     if let Some(path) = &path {
         let f = File::create(path).unwrap();
         #[cfg(feature = "display")]
@@ -269,7 +257,6 @@ pub fn gen_snark_shplonk<ConcreteCircuit: CircuitExt<Fr>>(
 /// Tries to deserialize a SNARK from the specified `path` using `bincode`.
 ///
 /// WARNING: The user must keep track of whether the SNARK was generated using the GWC or SHPLONK multi-open scheme.
-#[cfg(feature = "halo2-axiom")]
 pub fn read_snark(path: impl AsRef<Path>) -> Result<Snark, bincode::Error> {
     let f = File::open(path).map_err(Box::<bincode::ErrorKind>::from)?;
     bincode::deserialize_from(f)

--- a/snark-verifier-sdk/src/halo2.rs
+++ b/snark-verifier-sdk/src/halo2.rs
@@ -213,7 +213,6 @@ where
 
     let instances = circuit.instances();
     let proof = gen_proof::<ConcreteCircuit, P, V>(params, pk, circuit, instances.clone(), None);
-    // If we can't serialize the entire snark, at least serialize the proof
 
     let snark = Snark::new(protocol, instances, proof);
     if let Some(path) = &path {

--- a/snark-verifier-sdk/src/lib.rs
+++ b/snark-verifier-sdk/src/lib.rs
@@ -45,8 +45,7 @@ pub type PlonkSuccinctVerifier<AS> =
 pub type SHPLONK = KzgAs<Bn256, Bdfg21>;
 pub type GWC = KzgAs<Bn256, Gwc19>;
 
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "halo2-axiom", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Snark {
     pub protocol: PlonkProtocol<G1Affine>,
     pub instances: Vec<Vec<Fr>>,


### PR DESCRIPTION
Now that halo2-pse has the "derive_serde" feature