### PR TITLE
chore: keep old behavior of `EccInstructions::sum_with_const`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
           cache-on-failure: true
 
       - name: Install solc
-        run: (hash svm 2>/dev/null || cargo install --version 0.2.23 svm-rs) && svm install 0.8.19 && solc --version
+        run: (hash svm 2>/dev/null || cargo install --locked --git https://github.com/alloy-rs/svm-rs) && svm install 0.8.19 && solc --version
 
       - name: Run test
         run: cargo test --all --features "revm" -- --nocapture

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,15 @@ jobs:
         with:
           cache-on-failure: true
 
-      - name: Install solc
-        run: (hash svm 2>/dev/null || cargo install --locked --git https://github.com/alloy-rs/svm-rs) && svm install 0.8.19 && solc --version
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install solc-select and solc
+        run: |
+          pip3 install solc-select
+          solc-select use 0.8.19 --always-install
 
       - name: Run test
         run: cargo test --all --features "revm" -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,6 +1127,8 @@ dependencies = [
 [[package]]
 name = "halo2-axiom"
 version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d698920cd4cb189e6b90db50cb9393f1671f732f39665b907f745b5d45b51c8c"
 dependencies = [
  "blake2b_simd",
  "crossbeam",
@@ -1146,6 +1148,7 @@ dependencies = [
 [[package]]
 name = "halo2-base"
 version = "0.4.2-alpha.0"
+source = "git+https://github.com/axiom-crypto/halo2-lib.git?branch=develop#d23968cd00a0a0bbfe78f8bdaa83107749c51d85"
 dependencies = [
  "getset",
  "halo2-axiom",
@@ -1167,6 +1170,7 @@ dependencies = [
 [[package]]
 name = "halo2-ecc"
 version = "0.4.1"
+source = "git+https://github.com/axiom-crypto/halo2-lib.git?branch=develop#d23968cd00a0a0bbfe78f8bdaa83107749c51d85"
 dependencies = [
  "halo2-base",
  "itertools 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,10 +106,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "ark-ff"
@@ -536,28 +578,36 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.1"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.1"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
@@ -2616,6 +2666,9 @@ version = "0.1.7"
 dependencies = [
  "ark-std 0.3.0",
  "bincode",
+ "clap",
+ "clap_builder",
+ "clap_lex",
  "criterion",
  "criterion-macro",
  "crossterm 0.25.0",
@@ -2990,6 +3043,12 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"

--- a/snark-verifier-sdk/Cargo.toml
+++ b/snark-verifier-sdk/Cargo.toml
@@ -49,6 +49,9 @@ criterion-macro = "0.4"
 # loader_evm
 crossterm = { version = "0.25" }
 ratatui = { version = "0.24", default-features = false, features = ["crossterm"] }
+clap = "=4.4" # fix clap version to prevent requiring rustc 1.74
+clap_builder = "=4.4"
+clap_lex = "=0.6.0"
 
 [features]
 default = ["loader_halo2", "loader_evm", "halo2-axiom", "halo2-base/jemallocator", "display"]

--- a/snark-verifier/src/loader/halo2/shim.rs
+++ b/snark-verifier/src/loader/halo2/shim.rs
@@ -291,7 +291,7 @@ mod halo2_lib {
                 let constant = EccInstructions::assign_constant(self, ctx, constant);
                 Some(constant)
             };
-            self.sum::<C>(
+            self.sum_unsafe::<C>(
                 ctx.main(),
                 constant.into_iter().chain(values.iter().map(|v| v.deref().clone())),
             )


### PR DESCRIPTION
After https://github.com/axiom-crypto/halo2-lib/pull/244 the `EccChip::sum` was renamed `EccChip::sum_unsafe`. We update the naming to still use the `sum_unsafe` function so that snark verifier circuits do not change.