### PR TITLE
Convert `evm::evm_verify` to be fallible

### DIFF
--- a/snark-verifier-sdk/benches/standard_plonk.rs
+++ b/snark-verifier-sdk/benches/standard_plonk.rs
@@ -246,7 +246,7 @@ fn bench(c: &mut Criterion) {
             None,
         );
         #[cfg(feature = "revm")]
-        evm_verify(_deployment_code, instances, _proof);
+        evm_verify(_deployment_code, instances, _proof).expect("evm_verify should succeed");
     }
 }
 

--- a/snark-verifier-sdk/benches/zkevm_plus_state.rs
+++ b/snark-verifier-sdk/benches/zkevm_plus_state.rs
@@ -123,7 +123,7 @@ fn bench(c: &mut Criterion) {
             None,
         );
 
-        evm_verify(deployment_code, instances.clone(), proof);
+        evm_verify(deployment_code, instances.clone(), proof).expect("evm_verify should succeed");
 
         let start2 = start_timer!(|| "Create EVM GWC proof");
         let agg_circuit = AggregationCircuit::new::<SHPLONK>(
@@ -143,7 +143,7 @@ fn bench(c: &mut Criterion) {
             None,
         );
 
-        evm_verify(deployment_code, instances, proof);
+        evm_verify(deployment_code, instances, proof).expect("evm_verify should succeed");
     }
 
     // run benches

--- a/snark-verifier-sdk/examples/standard_plonk.rs
+++ b/snark-verifier-sdk/examples/standard_plonk.rs
@@ -215,5 +215,5 @@ fn main() {
         Some(Path::new("examples/StandardPlonkVerifier.sol")),
     );
     #[cfg(feature = "revm")]
-    evm_verify(_deployment_code, instances, _proof);
+    evm_verify(_deployment_code, instances, _proof).expect("evm_verify should succeed");
 }

--- a/snark-verifier-sdk/src/evm.rs
+++ b/snark-verifier-sdk/src/evm.rs
@@ -175,10 +175,15 @@ pub fn gen_evm_verifier_shplonk<C: CircuitExt<Fr>>(
 }
 
 #[cfg(feature = "revm")]
-pub fn evm_verify(deployment_code: Vec<u8>, instances: Vec<Vec<Fr>>, proof: Vec<u8>) {
+pub fn evm_verify(
+    deployment_code: Vec<u8>,
+    instances: Vec<Vec<Fr>>,
+    proof: Vec<u8>,
+) -> Result<u64, String> {
     let calldata = encode_calldata(&instances, &proof);
-    let gas_cost = snark_verifier::loader::evm::deploy_and_call(deployment_code, calldata).unwrap();
+    let gas_cost = snark_verifier::loader::evm::deploy_and_call(deployment_code, calldata)?;
     dbg!(gas_cost);
+    Ok(gas_cost)
 }
 
 pub fn write_calldata(instances: &[Vec<Fr>], proof: &[u8], path: &Path) -> io::Result<String> {


### PR DESCRIPTION
Change function signature to make `evm::evm_verify` fallible. Eventually can be used in `openvm_sdk::verify_evm_proof` to return the `Result` (instead of the current infallible approach).

If merged, I can open a pull request to `openvm_sdk`