### PR TITLE
give AggregationCircuit a simple generic trait type

### DIFF
--- a/snark-verifier-sdk/src/lib.rs
+++ b/snark-verifier-sdk/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(trait_alias)]
 #[cfg(feature = "display")]
 use ark_std::{end_timer, start_timer};
+use halo2::aggregation::AccumulationSchemeSDK;
 use halo2_base::halo2_proofs::{self};
 use halo2_proofs::{
     halo2curves::{
@@ -44,6 +45,9 @@ pub type PlonkSuccinctVerifier<AS> =
     verifier::plonk::PlonkSuccinctVerifier<AS, LimbsEncoding<LIMBS, BITS>>;
 pub type SHPLONK = KzgAs<Bn256, Bdfg21>;
 pub type GWC = KzgAs<Bn256, Gwc19>;
+
+impl AccumulationSchemeSDK for GWC {}
+impl AccumulationSchemeSDK for SHPLONK {}
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Snark {


### PR DESCRIPTION
cherry-pick of https://github.com/privacy-scaling-explorations/snark-verifier/pull/43 to avoid unstable trait alias